### PR TITLE
Fix image fallbacks and clean up unused code

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -133,37 +133,37 @@ const About = () => {
             <div className="grid grid-cols-2 gap-6">
               <div className="space-y-6">
                 <div className="relative overflow-hidden rounded-3xl shadow-xl group">
-                  <img
+                  <ImageWithFallback
                     src="https://images.unsplash.com/photo-1582750433449-648ed127bb54?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
                     alt="Diverse medical team collaborating on patient care"
                     className="w-full h-48 object-cover group-hover:scale-110 transition-transform duration-700"
-                      />
+                  />
                   <div className="absolute inset-0 bg-gradient-to-t from-blue-900/20 to-transparent"></div>
                 </div>
                 <div className="relative overflow-hidden rounded-3xl shadow-xl group">
-                  <img
+                  <ImageWithFallback
                     src="https://images.unsplash.com/photo-1576091160399-112ba8d25d1f?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
                     alt="Modern medical facility with advanced equipment"
                     className="w-full h-64 object-cover group-hover:scale-110 transition-transform duration-700"
-                      />
+                  />
                   <div className="absolute inset-0 bg-gradient-to-t from-blue-900/20 to-transparent"></div>
                 </div>
               </div>
               <div className="space-y-6 pt-12">
                 <div className="relative overflow-hidden rounded-3xl shadow-xl group">
-                  <img
+                  <ImageWithFallback
                     src="https://images.unsplash.com/photo-1559757175-0eb30cd8c063?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
                     alt="Healthcare professional providing compassionate patient care"
                     className="w-full h-64 object-cover group-hover:scale-110 transition-transform duration-700"
-                      />
+                  />
                   <div className="absolute inset-0 bg-gradient-to-t from-blue-900/20 to-transparent"></div>
                 </div>
                 <div className="relative overflow-hidden rounded-3xl shadow-xl group">
-                  <img
+                  <ImageWithFallback
                     src="https://images.unsplash.com/photo-1551190822-a9333d879b1f?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
                     alt="State-of-the-art medical equipment and technology"
                     className="w-full h-48 object-cover group-hover:scale-110 transition-transform duration-700"
-                      />
+                  />
                   <div className="absolute inset-0 bg-gradient-to-t from-blue-900/20 to-transparent"></div>
                 </div>
               </div>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,6 +1,5 @@
-import ImageWithFallback from './ImageWithFallback';
 import React, { useState } from 'react';
-import { Phone, Mail, MapPin, Clock, Calendar, Send, MessageCircle, Users, Award } from 'lucide-react';
+import { Phone, Mail, MapPin, Clock, Calendar, Send, MessageCircle } from 'lucide-react';
 
 const Contact = () => {
   const [formData, setFormData] = useState({

--- a/src/components/Doctors.tsx
+++ b/src/components/Doctors.tsx
@@ -1,6 +1,6 @@
 import ImageWithFallback from './ImageWithFallback';
 import React, { useEffect, useRef, useState } from 'react';
-import { Star, Calendar, MapPin, Award, GraduationCap } from 'lucide-react';
+import { Star, Calendar, MapPin, GraduationCap } from 'lucide-react';
 
 const Doctors = () => {
   const [visibleItems, setVisibleItems] = useState(new Set());
@@ -111,11 +111,11 @@ const Doctors = () => {
               style={{ transitionDelay: `${index * 150}ms` }}
             >
               <div className="relative overflow-hidden">
-                <img
+                <ImageWithFallback
                   src={doctor.image}
                   alt={`${doctor.name} - ${doctor.specialty}`}
                   className="w-full h-80 object-cover group-hover:scale-110 transition-transform duration-700"
-                 />
+                />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-transparent"></div>
                 
                 {/* Rating Badge */}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,3 @@
-import ImageWithFallback from './ImageWithFallback';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Facebook, Twitter, Instagram, Linkedin, Phone, Mail, MapPin, Clock, Heart, Award, Shield, Users } from 'lucide-react';

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,3 @@
-import ImageWithFallback from './ImageWithFallback';
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Menu, X, Phone, Clock, MapPin, ChevronDown } from 'lucide-react';

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -92,11 +92,11 @@ const Hero = () => {
           <div className={`relative transform transition-all duration-1000 delay-300 ${isVisible ? 'translate-x-0 opacity-100' : 'translate-x-20 opacity-0'}`}>
             <div className="relative z-10">
               <div className="relative overflow-hidden rounded-3xl shadow-2xl">
-                <img
+                <ImageWithFallback
                   src="https://images.unsplash.com/photo-1559757148-5c350d0d3c56?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
                   alt="Diverse medical team providing compassionate patient care"
                   className="w-full h-[700px] object-cover hover:scale-105 transition-transform duration-700"
-                 />
+                />
                 <div className="absolute inset-0 bg-gradient-to-t from-blue-900/20 to-transparent"></div>
               </div>
               

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,4 +1,3 @@
-import ImageWithFallback from './ImageWithFallback';
 import React, { useEffect, useRef, useState } from 'react';
 import { Heart, Brain, Eye, Bone, Baby, Stethoscope, Activity, Shield, ArrowRight } from 'lucide-react';
 

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -4,7 +4,6 @@ import { Star, Quote, ThumbsUp, Heart } from 'lucide-react';
 
 const Testimonials = () => {
   const [visibleItems, setVisibleItems] = useState(new Set());
-  const [activeTestimonial, setActiveTestimonial] = useState(0);
   const observerRef = useRef();
 
   useEffect(() => {
@@ -133,7 +132,7 @@ const Testimonials = () => {
               <div className="flex items-center justify-between mb-4">
                 <div className="flex items-center space-x-4">
                   <div className="relative">
-                    <img
+                    <ImageWithFallback
                       src={testimonial.image}
                       alt={`${testimonial.name} - satisfied patient`}
                       className="w-14 h-14 rounded-full object-cover border-2 border-orange-400 group-hover:border-orange-300 transition-colors"

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Award, Users, Clock, MapPin, CheckCircle, Heart, Shield, Target, Eye } from 'lucide-react';
 
 const AboutPage = () => {
-  const [isVisible, setIsVisible] = useState(false);
   const [counters, setCounters] = useState({ years: 0, doctors: 0, patients: 0, locations: 0 });
   const sectionRef = useRef();
 

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
+import ImageWithFallback from '../components/ImageWithFallback';
 import { Link } from 'react-router-dom';
-import { Calendar, User, ArrowRight, Search, Tag, Clock } from 'lucide-react';
+import { Calendar, User, ArrowRight, Search, Clock } from 'lucide-react';
 
 const BlogPage = () => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -164,7 +165,7 @@ const BlogPage = () => {
             <div className="bg-white rounded-3xl shadow-xl overflow-hidden hover:shadow-2xl transition-all duration-300">
               <div className="grid lg:grid-cols-2 gap-0">
                 <div className="relative overflow-hidden">
-                  <img
+                  <ImageWithFallback
                     src={featuredPost.image}
                     alt={featuredPost.title}
                     className="w-full h-96 lg:h-full object-cover hover:scale-105 transition-transform duration-500"
@@ -222,7 +223,7 @@ const BlogPage = () => {
             {regularPosts.map((post) => (
               <article key={post.id} className="bg-white rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden group hover:-translate-y-2">
                 <div className="relative overflow-hidden">
-                  <img
+                  <ImageWithFallback
                     src={post.image}
                     alt={post.title}
                     className="w-full h-48 object-cover group-hover:scale-110 transition-transform duration-500"

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { useParams, Link } from 'react-router-dom';
+import ImageWithFallback from '../components/ImageWithFallback';
+import { Link } from 'react-router-dom';
 import { Calendar, User, Clock, ArrowLeft, Share2, Heart, Bookmark } from 'lucide-react';
 
 const BlogPost = () => {
-  const { slug } = useParams();
 
   // This would typically come from an API or CMS
   const post = {
@@ -158,7 +158,7 @@ const BlogPost = () => {
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto">
             <div className="relative overflow-hidden rounded-3xl shadow-xl">
-              <img
+              <ImageWithFallback
                 src={post.image}
                 alt={post.title}
                 className="w-full h-96 object-cover"
@@ -187,7 +187,7 @@ const BlogPost = () => {
           <div className="max-w-4xl mx-auto">
             <div className="bg-white rounded-3xl p-8 shadow-lg">
               <div className="flex items-start space-x-6">
-                <img
+                <ImageWithFallback
                   src="https://images.unsplash.com/photo-1559839734-2b71ea197ec2?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
                   alt={post.author}
                   className="w-24 h-24 rounded-full object-cover"
@@ -235,7 +235,7 @@ const BlogPost = () => {
                   className="group bg-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden hover:-translate-y-2"
                 >
                   <div className="relative overflow-hidden">
-                    <img
+                    <ImageWithFallback
                       src={article.image}
                       alt={article.title}
                       className="w-full h-48 object-cover group-hover:scale-110 transition-transform duration-500"

--- a/src/pages/Careers.tsx
+++ b/src/pages/Careers.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Briefcase, MapPin, Clock, DollarSign, Users, Award, Heart, GraduationCap, Search, Filter } from 'lucide-react';
+import { Briefcase, MapPin, Clock, DollarSign, Users, Heart, GraduationCap, Search, Filter } from 'lucide-react';
 
 const Careers = () => {
   const [searchTerm, setSearchTerm] = useState('');

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Phone, Mail, MapPin, Clock, Calendar, Send, MessageCircle, Users, Award, Navigation, Car, Bus } from 'lucide-react';
+import { Phone, Mail, MapPin, Clock, Calendar, Send, MessageCircle, Navigation, Car, Bus } from 'lucide-react';
 
 const ContactPage = () => {
   const [formData, setFormData] = useState({

--- a/src/pages/TestimonialsPage.tsx
+++ b/src/pages/TestimonialsPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Star, Quote, ThumbsUp, Heart, Calendar, User, Award, Shield } from 'lucide-react';
+import { Star, Quote, ThumbsUp, Heart, User, Award, Shield } from 'lucide-react';
+import ImageWithFallback from '../components/ImageWithFallback';
 
 const TestimonialsPage = () => {
   const [visibleItems, setVisibleItems] = useState(new Set());
@@ -256,7 +257,7 @@ const TestimonialsPage = () => {
                 <div className="flex items-center justify-between mb-4">
                   <div className="flex items-center space-x-4">
                     <div className="relative">
-                      <img
+                    <ImageWithFallback
                         src={testimonial.image}
                         alt={testimonial.name}
                         className="w-14 h-14 rounded-full object-cover border-2 border-blue-200 group-hover:border-blue-300 transition-colors"
@@ -329,7 +330,7 @@ const TestimonialsPage = () => {
             
             <div className="grid lg:grid-cols-2 gap-12 items-center">
               <div className="relative">
-                <img
+                <ImageWithFallback
                   src={testimonials[6].image}
                   alt={testimonials[6].name}
                   className="w-full h-96 object-cover rounded-3xl shadow-xl"
@@ -359,7 +360,7 @@ const TestimonialsPage = () => {
                 </blockquote>
                 
                 <div className="flex items-center space-x-4">
-                  <img
+                  <ImageWithFallback
                     src={testimonials[6].image}
                     alt={testimonials[6].name}
                     className="w-16 h-16 rounded-full object-cover border-2 border-blue-200"


### PR DESCRIPTION
## Summary
- replace several `<img>` elements with `ImageWithFallback` so broken images show a placeholder
- remove unused imports and variables flagged by ESLint
- keep lint warnings to a minimum

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d4c7c201483248f559e1fd7b5be25