### PR TITLE
Fix overlap contrast in hero badge

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -101,7 +101,7 @@ const Hero = () => {
               </div>
               
               {/* Floating Cards */}
-              <div className="absolute -top-8 -left-8 bg-white rounded-2xl p-6 shadow-2xl animate-float">
+              <div className="absolute -top-8 -left-8 bg-white rounded-2xl p-6 shadow-2xl border border-gray-300 animate-float">
                 <div className="flex items-center space-x-4">
                   <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
                     <div className="w-6 h-6 bg-green-500 rounded-full animate-pulse"></div>


### PR DESCRIPTION
## Summary
- adjust hero overlay styling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850610db2088324afb18b455d7ceda2