### PR TITLE
Implement new color palette

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -67,19 +67,19 @@ const About = () => {
           <div className={`space-y-8 transform transition-all duration-1000 ${isVisible ? 'translate-x-0 opacity-100' : '-translate-x-20 opacity-0'}`}>
             <div className="space-y-6">
               <div className="inline-block">
-                <span className="bg-gradient-to-r from-blue-600 to-blue-700 text-white px-6 py-3 rounded-full text-sm font-semibold shadow-lg">
+                <span className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-6 py-3 rounded-full text-sm font-semibold shadow-lg">
                   About BigMedix
                 </span>
               </div>
               
-              <h2 className="text-4xl md:text-6xl font-bold text-gray-900 leading-tight">
+              <h2 className="text-4xl md:text-6xl font-bold text-[#000000] leading-tight">
                 Trusted Healthcare
                 <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-orange-500 block">
                   Since 1998
                 </span>
               </h2>
               
-              <p className="text-xl text-gray-600 leading-relaxed">
+              <p className="text-xl text-[#4A4A4A] leading-relaxed">
                 For over two decades, BigMedix has been at the forefront of medical excellence, providing compassionate, comprehensive healthcare services to our community. Our commitment to innovation and patient-centered care has made us a trusted name in healthcare.
               </p>
             </div>
@@ -104,10 +104,10 @@ const About = () => {
                     <CheckCircle className="text-white" size={16}     />
                   </div>
                   <div>
-                    <h4 className="font-bold text-gray-900 mb-2 text-lg group-hover:text-blue-600 transition-colors">
+                    <h4 className="font-bold text-[#000000] mb-2 text-lg group-hover:text-blue-600 transition-colors">
                       {item.title}
                     </h4>
-                    <p className="text-gray-600 leading-relaxed">
+                    <p className="text-[#4A4A4A] leading-relaxed">
                       {item.description}
                     </p>
                   </div>
@@ -116,7 +116,7 @@ const About = () => {
             </div>
 
             <div className="flex flex-col sm:flex-row gap-4">
-              <button className="bg-gradient-to-r from-blue-600 to-blue-700 text-white px-8 py-4 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105 hover:-translate-y-1">
+              <button className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-8 py-4 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105 hover:-translate-y-1">
                 Learn More About Us
               </button>
               
@@ -183,10 +183,10 @@ const About = () => {
               <div className={`w-20 h-20 bg-gradient-to-br ${stat.color} rounded-3xl flex items-center justify-center mx-auto mb-4 group-hover:scale-110 transition-all duration-300 shadow-lg`}>
                 <stat.icon className="text-white" size={36}     />
               </div>
-              <div className="text-4xl font-bold text-gray-900 mb-2 group-hover:text-blue-600 transition-colors">
+              <div className="text-4xl font-bold text-[#000000] mb-2 group-hover:text-blue-600 transition-colors">
                 {stat.number}
               </div>
-              <div className="text-gray-600 font-medium">{stat.label}</div>
+              <div className="text-[#4A4A4A] font-medium">{stat.label}</div>
             </div>
           ))}
         </div>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -20,7 +20,7 @@ const Contact = () => {
   };
 
   return (
-    <section id="contact" className="py-20 bg-gradient-to-br from-blue-50 to-white relative overflow-hidden">
+    <section id="contact" className="py-20 bg-[#F4F9F7] relative overflow-hidden">
       {/* Background Pattern */}
       <div className="absolute inset-0 opacity-5">
         <div className="absolute top-20 left-20 w-64 h-64 bg-blue-500 rounded-full blur-3xl"></div>
@@ -30,17 +30,17 @@ const Contact = () => {
       <div className="container mx-auto px-4 relative z-10">
         <div className="text-center mb-16">
           <div className="inline-block mb-6">
-            <span className="bg-gradient-to-r from-blue-600 to-blue-700 text-white px-6 py-3 rounded-full text-sm font-semibold shadow-lg">
+            <span className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-6 py-3 rounded-full text-sm font-semibold shadow-lg">
               Get In Touch
             </span>
           </div>
-          <h2 className="text-4xl md:text-6xl font-bold text-gray-900 mb-6 leading-tight">
+          <h2 className="text-4xl md:text-6xl font-bold text-[#000000] mb-6 leading-tight">
             Contact Us
             <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-orange-500 block">
               Today
             </span>
           </h2>
-          <p className="text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed">
+          <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto leading-relaxed">
             Ready to take the next step in your healthcare journey? Get in touch with us to schedule an appointment or learn more about our services.
           </p>
         </div>
@@ -48,46 +48,46 @@ const Contact = () => {
         <div className="grid lg:grid-cols-3 gap-12 mb-16">
           {/* Contact Info Cards */}
           <div className="lg:col-span-1 space-y-6">
-            <div className="bg-white rounded-3xl p-8 shadow-xl hover:shadow-2xl transition-all duration-300 border border-gray-100 group hover:-translate-y-2">
+            <div className="bg-[#FAFAFA] rounded-3xl p-8 shadow-xl hover:shadow-2xl transition-all duration-300 border border-gray-100 group hover:-translate-y-2">
               <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-600 rounded-3xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300">
                 <Phone className="text-white" size={28} />
               </div>
-              <h3 className="text-2xl font-bold text-gray-900 mb-4 group-hover:text-blue-600 transition-colors">Phone</h3>
-              <p className="text-gray-600 mb-4 leading-relaxed">Call us for appointments or emergencies</p>
+              <h3 className="text-2xl font-bold text-[#000000] mb-4 group-hover:text-blue-600 transition-colors">Phone</h3>
+              <p className="text-[#4A4A4A] mb-4 leading-relaxed">Call us for appointments or emergencies</p>
               <div className="space-y-2">
                 <div className="font-bold text-blue-600 text-lg">+1 (555) 123-4567</div>
                 <div className="text-sm text-gray-500">Emergency: +1 (555) 911-HELP</div>
               </div>
             </div>
 
-            <div className="bg-white rounded-3xl p-8 shadow-xl hover:shadow-2xl transition-all duration-300 border border-gray-100 group hover:-translate-y-2">
+            <div className="bg-[#FAFAFA] rounded-3xl p-8 shadow-xl hover:shadow-2xl transition-all duration-300 border border-gray-100 group hover:-translate-y-2">
               <div className="w-16 h-16 bg-gradient-to-br from-green-500 to-green-600 rounded-3xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300">
                 <Mail className="text-white" size={28} />
               </div>
-              <h3 className="text-2xl font-bold text-gray-900 mb-4 group-hover:text-green-600 transition-colors">Email</h3>
-              <p className="text-gray-600 mb-4 leading-relaxed">Send us your questions or concerns</p>
+              <h3 className="text-2xl font-bold text-[#000000] mb-4 group-hover:text-green-600 transition-colors">Email</h3>
+              <p className="text-[#4A4A4A] mb-4 leading-relaxed">Send us your questions or concerns</p>
               <div className="space-y-2">
                 <div className="font-bold text-green-600 text-lg">info@bigmedix.com</div>
                 <div className="text-sm text-gray-500">appointments@bigmedix.com</div>
               </div>
             </div>
 
-            <div className="bg-white rounded-3xl p-8 shadow-xl hover:shadow-2xl transition-all duration-300 border border-gray-100 group hover:-translate-y-2">
+            <div className="bg-[#FAFAFA] rounded-3xl p-8 shadow-xl hover:shadow-2xl transition-all duration-300 border border-gray-100 group hover:-translate-y-2">
               <div className="w-16 h-16 bg-gradient-to-br from-orange-500 to-orange-600 rounded-3xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300">
                 <MapPin className="text-white" size={28} />
               </div>
-              <h3 className="text-2xl font-bold text-gray-900 mb-4 group-hover:text-orange-600 transition-colors">Location</h3>
-              <p className="text-gray-600 mb-4 leading-relaxed">Visit us at our main medical center</p>
+              <h3 className="text-2xl font-bold text-[#000000] mb-4 group-hover:text-orange-600 transition-colors">Location</h3>
+              <p className="text-[#4A4A4A] mb-4 leading-relaxed">Visit us at our main medical center</p>
               <div className="font-bold text-orange-600 text-lg">123 Medical Plaza, Health City, HC 12345</div>
             </div>
           </div>
 
           {/* Contact Form */}
           <div className="lg:col-span-2">
-            <div className="bg-white rounded-3xl p-8 shadow-xl border border-gray-100">
+            <div className="bg-[#FAFAFA] rounded-3xl p-8 shadow-xl border border-gray-100">
               <div className="flex items-center mb-8">
                 <Calendar className="text-blue-600 mr-4" size={32} />
-                <h3 className="text-3xl font-bold text-gray-900">Book an Appointment</h3>
+                <h3 className="text-3xl font-bold text-[#000000]">Book an Appointment</h3>
               </div>
               
               <form className="space-y-6">
@@ -186,7 +186,7 @@ const Contact = () => {
 
                 <button
                   type="submit"
-                  className="w-full bg-gradient-to-r from-blue-600 to-blue-700 text-white py-4 rounded-2xl hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-bold flex items-center justify-center space-x-3 shadow-xl hover:shadow-2xl transform hover:scale-105 hover:-translate-y-1"
+                  className="w-full bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white py-4 rounded-2xl hover:opacity-90 transition-all duration-300 font-bold flex items-center justify-center space-x-3 shadow-xl hover:shadow-2xl transform hover:scale-105 hover:-translate-y-1"
                 >
                   <Send size={24} />
                   <span>Book Appointment</span>
@@ -198,7 +198,7 @@ const Contact = () => {
 
         {/* Hours and Additional Info */}
         <div className="grid md:grid-cols-3 gap-8">
-          <div className="bg-gradient-to-br from-blue-600 to-blue-700 rounded-3xl p-8 text-white shadow-xl">
+          <div className="bg-gradient-to-br from-[#0F4537] to-[#2E6656] rounded-3xl p-8 text-white shadow-xl">
             <div className="flex items-center mb-6">
               <Clock className="mr-4" size={32} />
               <h3 className="text-2xl font-bold">Working Hours</h3>

--- a/src/components/Doctors.tsx
+++ b/src/components/Doctors.tsx
@@ -82,17 +82,17 @@ const Doctors = () => {
       <div className="container mx-auto px-4 relative z-10">
         <div className="text-center mb-16">
           <div className="inline-block mb-6">
-            <span className="bg-gradient-to-r from-blue-600 to-blue-700 text-white px-6 py-3 rounded-full text-sm font-semibold shadow-lg">
+            <span className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-6 py-3 rounded-full text-sm font-semibold shadow-lg">
               Our Medical Team
             </span>
           </div>
-          <h2 className="text-4xl md:text-6xl font-bold text-gray-900 mb-6 leading-tight">
+          <h2 className="text-4xl md:text-6xl font-bold text-[#000000] mb-6 leading-tight">
             Meet Our Expert
             <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-orange-500 block">
               Doctors
             </span>
           </h2>
-          <p className="text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed">
+          <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto leading-relaxed">
             Our team of board-certified physicians brings decades of experience and expertise to provide you with the highest quality medical care.
           </p>
         </div>
@@ -125,17 +125,17 @@ const Doctors = () => {
                 </div>
 
                 {/* Specialty Badge */}
-                <div className="absolute bottom-4 left-4 bg-gradient-to-r from-blue-600 to-blue-700 text-white px-4 py-2 rounded-full text-sm font-semibold shadow-lg">
+                <div className="absolute bottom-4 left-4 bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-4 py-2 rounded-full text-sm font-semibold shadow-lg">
                   {doctor.specialty}
                 </div>
               </div>
               
               <div className="p-6 space-y-4">
                 <div>
-                  <h3 className="text-2xl font-bold text-gray-900 mb-2 group-hover:text-blue-600 transition-colors">
+                  <h3 className="text-2xl font-bold text-[#000000] mb-2 group-hover:text-blue-600 transition-colors">
                     {doctor.name}
                   </h3>
-                  <div className="flex items-center space-x-4 text-sm text-gray-600 mb-4">
+                  <div className="flex items-center space-x-4 text-sm text-[#4A4A4A] mb-4">
                     <div className="flex items-center space-x-1">
                       <Calendar size={16}  />
                       <span>{doctor.experience}</span>
@@ -148,13 +148,13 @@ const Doctors = () => {
                 </div>
 
                 <div className="space-y-3">
-                  <div className="flex items-center space-x-2 text-sm text-gray-600">
+                  <div className="flex items-center space-x-2 text-sm text-[#4A4A4A]">
                     <GraduationCap size={16} className="text-blue-600"  />
                     <span className="font-medium">{doctor.education}</span>
                   </div>
                   
                   <div className="flex items-center justify-between text-sm">
-                    <span className="text-gray-600">{doctor.reviews} patient reviews</span>
+                    <span className="text-[#4A4A4A]">{doctor.reviews} patient reviews</span>
                     <div className="flex items-center space-x-1">
                       {[...Array(5)].map((_, i) => (
                         <Star
@@ -168,7 +168,7 @@ const Doctors = () => {
                 </div>
 
                 <div className="pt-4 border-t border-gray-100">
-                  <div className="text-sm text-gray-600 mb-3">Specialties:</div>
+                  <div className="text-sm text-[#4A4A4A] mb-3">Specialties:</div>
                   <div className="flex flex-wrap gap-2">
                     {doctor.specialties.slice(0, 2).map((specialty, i) => (
                       <span key={i} className="bg-blue-50 text-blue-600 px-3 py-1 rounded-full text-xs font-medium">
@@ -176,14 +176,14 @@ const Doctors = () => {
                       </span>
                     ))}
                     {doctor.specialties.length > 2 && (
-                      <span className="bg-gray-100 text-gray-600 px-3 py-1 rounded-full text-xs font-medium">
+                      <span className="bg-gray-100 text-[#4A4A4A] px-3 py-1 rounded-full text-xs font-medium">
                         +{doctor.specialties.length - 2} more
                       </span>
                     )}
                   </div>
                 </div>
 
-                <button className="w-full bg-gradient-to-r from-blue-600 to-blue-700 text-white py-3 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105">
+                <button className="w-full bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white py-3 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105">
                   Book Appointment
                 </button>
               </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -65,7 +65,7 @@ const Header = () => {
               to="/" 
               className={`font-semibold transition-all duration-300 hover:scale-105 ${
                 isActive('/') 
-                  ? (isScrolled ? 'text-blue-600' : 'text-orange-300') 
+                  ? (isScrolled ? 'text-blue-600' : 'text-[#F8753D]')
                   : (isScrolled ? 'text-gray-700 hover:text-blue-600' : 'text-white hover:text-blue-200')
               }`}
             >
@@ -75,7 +75,7 @@ const Header = () => {
               to="/about" 
               className={`font-semibold transition-all duration-300 hover:scale-105 ${
                 isActive('/about') 
-                  ? (isScrolled ? 'text-blue-600' : 'text-orange-300') 
+                  ? (isScrolled ? 'text-blue-600' : 'text-[#F8753D]')
                   : (isScrolled ? 'text-gray-700 hover:text-blue-600' : 'text-white hover:text-blue-200')
               }`}
             >
@@ -86,7 +86,7 @@ const Header = () => {
               <button 
                 className={`flex items-center space-x-1 font-semibold transition-all duration-300 hover:scale-105 ${
                   isActive('/services') 
-                    ? (isScrolled ? 'text-blue-600' : 'text-orange-300') 
+                    ? (isScrolled ? 'text-blue-600' : 'text-[#F8753D]')
                     : (isScrolled ? 'text-gray-700 hover:text-blue-600' : 'text-white hover:text-blue-200')
                 }`}
                 onMouseEnter={() => setIsServicesOpen(true)}
@@ -119,7 +119,7 @@ const Header = () => {
               to="/doctors" 
               className={`font-semibold transition-all duration-300 hover:scale-105 ${
                 isActive('/doctors') 
-                  ? (isScrolled ? 'text-blue-600' : 'text-orange-300') 
+                  ? (isScrolled ? 'text-blue-600' : 'text-[#F8753D]')
                   : (isScrolled ? 'text-gray-700 hover:text-blue-600' : 'text-white hover:text-blue-200')
               }`}
             >
@@ -129,7 +129,7 @@ const Header = () => {
               to="/blog" 
               className={`font-semibold transition-all duration-300 hover:scale-105 ${
                 isActive('/blog') 
-                  ? (isScrolled ? 'text-blue-600' : 'text-orange-300') 
+                  ? (isScrolled ? 'text-blue-600' : 'text-[#F8753D]')
                   : (isScrolled ? 'text-gray-700 hover:text-blue-600' : 'text-white hover:text-blue-200')
               }`}
             >
@@ -139,7 +139,7 @@ const Header = () => {
               to="/contact" 
               className={`font-semibold transition-all duration-300 hover:scale-105 ${
                 isActive('/contact') 
-                  ? (isScrolled ? 'text-blue-600' : 'text-orange-300') 
+                  ? (isScrolled ? 'text-blue-600' : 'text-[#F8753D]')
                   : (isScrolled ? 'text-gray-700 hover:text-blue-600' : 'text-white hover:text-blue-200')
               }`}
             >
@@ -147,7 +147,7 @@ const Header = () => {
             </Link>
             <Link 
               to="/contact"
-              className="bg-gradient-to-r from-orange-500 to-red-500 text-white px-8 py-3 rounded-full hover:from-orange-600 hover:to-red-600 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105 hover:-translate-y-1"
+              className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-8 py-3 rounded-full hover:opacity-90 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105 hover:-translate-y-1"
             >
               Book Appointment
             </Link>
@@ -175,7 +175,7 @@ const Header = () => {
               <Link to="/contact" className="text-gray-700 hover:text-blue-600 transition-colors font-medium py-2 hover:bg-blue-50 px-4 rounded-lg">Contact</Link>
               <Link 
                 to="/contact"
-                className="bg-gradient-to-r from-orange-500 to-red-500 text-white px-6 py-3 rounded-full hover:from-orange-600 hover:to-red-600 transition-all duration-300 font-medium w-fit transform hover:scale-105"
+                className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-6 py-3 rounded-full hover:opacity-90 transition-all duration-300 font-medium w-fit transform hover:scale-105"
               >
                 Book Appointment
               </Link>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -10,7 +10,7 @@ const Hero = () => {
   }, []);
 
   return (
-    <section id="home" className="relative min-h-screen bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 overflow-hidden">
+    <section id="home" className="relative min-h-screen bg-gradient-to-br from-[#0F4537] to-[#2E6656] overflow-hidden">
       {/* Background Pattern */}
       <div className="absolute inset-0 opacity-10">
         <div className="absolute top-20 left-20 w-32 h-32 bg-white rounded-full animate-float"></div>
@@ -23,14 +23,14 @@ const Hero = () => {
           <div className={`space-y-8 transform transition-all duration-1000 ${isVisible ? 'translate-x-0 opacity-100' : '-translate-x-20 opacity-0'}`}>
             <div className="space-y-6">
               <div className="inline-block">
-                <span className="bg-gradient-to-r from-orange-500 to-red-500 text-white px-6 py-2 rounded-full text-sm font-semibold animate-pulse">
+                <span className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-6 py-2 rounded-full text-sm font-semibold animate-pulse">
                   #1 Medical Center in the City
                 </span>
               </div>
               
               <h1 className="text-5xl lg:text-7xl font-bold text-white leading-tight">
                 Your Health is Our
-                <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-400 to-red-400 block animate-gradient">
+                <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#FA6F42] to-[#F8753D] block animate-gradient">
                   Top Priority
                 </span>
               </h1>
@@ -41,12 +41,12 @@ const Hero = () => {
             </div>
 
             <div className="flex flex-col sm:flex-row gap-6">
-              <button className="group bg-gradient-to-r from-orange-500 to-red-500 text-white px-8 py-4 rounded-full hover:from-orange-600 hover:to-red-600 transition-all duration-300 font-semibold flex items-center justify-center space-x-3 shadow-2xl hover:shadow-orange-500/25 transform hover:scale-105 hover:-translate-y-1">
+              <button className="group bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-8 py-4 rounded-full hover:opacity-90 transition-all duration-300 font-semibold flex items-center justify-center space-x-3 shadow-2xl hover:shadow-orange-500/25 transform hover:scale-105 hover:-translate-y-1">
                 <span>Book Appointment</span>
                 <ArrowRight size={20} className="group-hover:translate-x-1 transition-transform"  />
               </button>
               
-              <button className="group flex items-center space-x-3 text-white hover:text-orange-300 transition-all duration-300 font-semibold">
+              <button className="group flex items-center space-x-3 text-white hover:text-[#F8753D] transition-all duration-300 font-semibold">
                 <div className="w-12 h-12 bg-white/20 backdrop-blur-sm rounded-full flex items-center justify-center group-hover:bg-white/30 transition-all duration-300 group-hover:scale-110">
                   <Play size={20} className="ml-1"  />
                 </div>
@@ -57,33 +57,33 @@ const Hero = () => {
             <div className="grid grid-cols-2 md:grid-cols-4 gap-6 pt-8">
               <div className="text-center group cursor-pointer">
                 <div className="w-16 h-16 bg-white/10 backdrop-blur-sm rounded-2xl flex items-center justify-center mx-auto mb-4 group-hover:bg-white/20 transition-all duration-300 group-hover:scale-110">
-                  <Shield className="text-orange-400" size={32}  />
+                  <Shield className="text-[#F8753D]" size={32}  />
                 </div>
-                <div className="text-3xl font-bold text-white group-hover:text-orange-300 transition-colors">24/7</div>
+                <div className="text-3xl font-bold text-white group-hover:text-[#F8753D] transition-colors">24/7</div>
                 <div className="text-blue-200 text-sm">Emergency Care</div>
               </div>
               
               <div className="text-center group cursor-pointer">
                 <div className="w-16 h-16 bg-white/10 backdrop-blur-sm rounded-2xl flex items-center justify-center mx-auto mb-4 group-hover:bg-white/20 transition-all duration-300 group-hover:scale-110">
-                  <Award className="text-orange-400" size={32}  />
+                  <Award className="text-[#F8753D]" size={32}  />
                 </div>
-                <div className="text-3xl font-bold text-white group-hover:text-orange-300 transition-colors">25+</div>
+                <div className="text-3xl font-bold text-white group-hover:text-[#F8753D] transition-colors">25+</div>
                 <div className="text-blue-200 text-sm">Years Experience</div>
               </div>
               
               <div className="text-center group cursor-pointer">
                 <div className="w-16 h-16 bg-white/10 backdrop-blur-sm rounded-2xl flex items-center justify-center mx-auto mb-4 group-hover:bg-white/20 transition-all duration-300 group-hover:scale-110">
-                  <Users className="text-orange-400" size={32}  />
+                  <Users className="text-[#F8753D]" size={32}  />
                 </div>
-                <div className="text-3xl font-bold text-white group-hover:text-orange-300 transition-colors">50+</div>
+                <div className="text-3xl font-bold text-white group-hover:text-[#F8753D] transition-colors">50+</div>
                 <div className="text-blue-200 text-sm">Expert Doctors</div>
               </div>
               
               <div className="text-center group cursor-pointer">
                 <div className="w-16 h-16 bg-white/10 backdrop-blur-sm rounded-2xl flex items-center justify-center mx-auto mb-4 group-hover:bg-white/20 transition-all duration-300 group-hover:scale-110">
-                  <Clock className="text-orange-400" size={32}  />
+                  <Clock className="text-[#F8753D]" size={32}  />
                 </div>
-                <div className="text-3xl font-bold text-white group-hover:text-orange-300 transition-colors">15K+</div>
+                <div className="text-3xl font-bold text-white group-hover:text-[#F8753D] transition-colors">15K+</div>
                 <div className="text-blue-200 text-sm">Happy Patients</div>
               </div>
             </div>
@@ -108,7 +108,7 @@ const Hero = () => {
                   </div>
                   <div>
                     <div className="font-bold text-gray-800">24/7 Available</div>
-                    <div className="text-sm text-gray-600">Emergency Services</div>
+                    <div className="text-sm text-[#4A4A4A]">Emergency Services</div>
                   </div>
                 </div>
               </div>
@@ -120,14 +120,14 @@ const Hero = () => {
                   </div>
                   <div>
                     <div className="font-bold text-gray-800">Award Winning</div>
-                    <div className="text-sm text-gray-600">Healthcare Excellence</div>
+                    <div className="text-sm text-[#4A4A4A]">Healthcare Excellence</div>
                   </div>
                 </div>
               </div>
             </div>
             
             {/* Background Decorations */}
-            <div className="absolute -top-4 -right-4 w-full h-full bg-gradient-to-br from-orange-400 to-red-500 rounded-3xl -z-10 opacity-20"></div>
+            <div className="absolute -top-4 -right-4 w-full h-full bg-gradient-to-br from-[#FA6F42] to-[#F8753D] rounded-3xl -z-10 opacity-20"></div>
             <div className="absolute -bottom-8 -left-8 w-32 h-32 bg-gradient-to-br from-blue-400 to-blue-600 rounded-full -z-20 animate-pulse"></div>
           </div>
         </div>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -83,7 +83,7 @@ const Services = () => {
   ];
 
   return (
-    <section id="services" className="py-20 bg-gradient-to-br from-gray-50 to-blue-50 relative overflow-hidden">
+    <section id="services" className="py-20 bg-[#F4F9F7] relative overflow-hidden">
       {/* Background Pattern */}
       <div className="absolute inset-0 opacity-5">
         <div className="absolute top-20 left-20 w-64 h-64 bg-blue-500 rounded-full blur-3xl"></div>
@@ -93,17 +93,17 @@ const Services = () => {
       <div className="container mx-auto px-4 relative z-10">
         <div className="text-center mb-16">
           <div className="inline-block mb-6">
-            <span className="bg-gradient-to-r from-blue-600 to-blue-700 text-white px-6 py-3 rounded-full text-sm font-semibold shadow-lg">
+            <span className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-6 py-3 rounded-full text-sm font-semibold shadow-lg">
               Our Medical Services
             </span>
           </div>
-          <h2 className="text-4xl md:text-6xl font-bold text-gray-900 mb-6 leading-tight">
+          <h2 className="text-4xl md:text-6xl font-bold text-[#000000] mb-6 leading-tight">
             Comprehensive Healthcare
-            <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-orange-500 block">
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#FA6F42] to-[#F8753D] block">
               Solutions
             </span>
           </h2>
-          <p className="text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed">
+          <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto leading-relaxed">
             We provide world-class medical services across multiple specialties, ensuring you receive the best possible care for all your health needs.
           </p>
         </div>
@@ -114,7 +114,7 @@ const Services = () => {
               key={index}
               data-index={index}
               data-animate="service"
-              className={`group bg-white rounded-3xl p-8 shadow-lg hover:shadow-2xl transition-all duration-500 border border-gray-100 cursor-pointer transform hover:-translate-y-4 ${
+              className={`group bg-[#FAFAFA] rounded-3xl p-8 shadow-lg hover:shadow-2xl transition-all duration-500 border border-gray-100 cursor-pointer transform hover:-translate-y-4 ${
                 visibleItems.has(index.toString()) 
                   ? 'translate-y-0 opacity-100' 
                   : 'translate-y-8 opacity-0'
@@ -125,11 +125,11 @@ const Services = () => {
                 <service.icon className="text-white" size={36} />
               </div>
               
-              <h3 className="text-2xl font-bold text-gray-900 mb-4 group-hover:text-blue-600 transition-colors">
+              <h3 className="text-2xl font-bold text-[#000000] mb-4 group-hover:text-blue-600 transition-colors">
                 {service.title}
               </h3>
               
-              <p className="text-gray-600 mb-6 leading-relaxed">
+              <p className="text-[#4A4A4A] mb-6 leading-relaxed">
                 {service.description}
               </p>
               
@@ -151,7 +151,7 @@ const Services = () => {
         </div>
 
         <div className="text-center mt-16">
-          <button className="bg-gradient-to-r from-blue-600 to-blue-700 text-white px-10 py-4 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105 hover:-translate-y-1">
+          <button className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-10 py-4 rounded-full hover:opacity-90 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105 hover:-translate-y-1">
             View All Services
           </button>
         </div>

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -93,7 +93,7 @@ const Testimonials = () => {
       <div className="container mx-auto px-4 relative z-10">
         <div className="text-center mb-16">
           <div className="inline-block mb-6">
-            <span className="bg-gradient-to-r from-orange-500 to-red-500 text-white px-6 py-3 rounded-full text-sm font-semibold shadow-lg animate-pulse">
+            <span className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-6 py-3 rounded-full text-sm font-semibold shadow-lg animate-pulse">
               Patient Stories
             </span>
           </div>

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -141,9 +141,9 @@ const AboutPage = () => {
   return (
     <div className="pt-32">
       {/* Hero Section */}
-      <section className="py-20 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white relative overflow-hidden">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white relative overflow-hidden">
         <div className="absolute inset-0 opacity-10">
-          <div className="absolute top-20 left-20 w-64 h-64 bg-white rounded-full blur-3xl"></div>
+          <div className="absolute top-20 left-20 w-64 h-64 bg-[#FAFAFA] rounded-full blur-3xl"></div>
           <div className="absolute bottom-20 right-20 w-64 h-64 bg-orange-500 rounded-full blur-3xl"></div>
         </div>
         
@@ -151,7 +151,7 @@ const AboutPage = () => {
           <div className="text-center mb-16">
             <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
               About
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-400 to-red-400 block">
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#FA6F42] to-[#F8753D] block">
                 BigMedix
               </span>
             </h1>
@@ -163,17 +163,17 @@ const AboutPage = () => {
       </section>
 
       {/* Mission & History */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="grid lg:grid-cols-2 gap-16 items-center">
             <div className="space-y-8">
               <div>
-                <h2 className="text-4xl font-bold text-gray-900 mb-6">Our Mission</h2>
-                <p className="text-xl text-gray-600 leading-relaxed mb-6">
+                <h2 className="text-4xl font-bold text-[#000000] mb-6">Our Mission</h2>
+                <p className="text-xl text-[#4A4A4A] leading-relaxed mb-6">
                   To provide world-class healthcare services that combine medical excellence with compassionate care, 
                   ensuring every patient receives personalized treatment in a safe, comfortable environment.
                 </p>
-                <p className="text-lg text-gray-600 leading-relaxed">
+                <p className="text-lg text-[#4A4A4A] leading-relaxed">
                   Since 1998, BigMedix has been at the forefront of medical innovation, continuously expanding our 
                   services and expertise to meet the evolving healthcare needs of our community.
                 </p>
@@ -209,20 +209,20 @@ const AboutPage = () => {
       <section className="py-20 bg-gray-50">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Our Core Values</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Our Core Values</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               These fundamental principles guide everything we do and shape our commitment to exceptional healthcare.
             </p>
           </div>
           
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
             {coreValues.map((value, index) => (
-              <div key={index} className="bg-white rounded-3xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 text-center group hover:-translate-y-2">
+              <div key={index} className="bg-[#FAFAFA] rounded-3xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 text-center group hover:-translate-y-2">
                 <div className={`w-20 h-20 bg-gradient-to-br ${value.color} rounded-3xl flex items-center justify-center mx-auto mb-6 group-hover:scale-110 transition-transform duration-300`}>
                   <value.icon className="text-white" size={36} />
                 </div>
-                <h3 className="text-2xl font-bold text-gray-900 mb-4">{value.title}</h3>
-                <p className="text-gray-600 leading-relaxed">{value.description}</p>
+                <h3 className="text-2xl font-bold text-[#000000] mb-4">{value.title}</h3>
+                <p className="text-[#4A4A4A] leading-relaxed">{value.description}</p>
               </div>
             ))}
           </div>
@@ -230,18 +230,18 @@ const AboutPage = () => {
       </section>
 
       {/* Leadership Team */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Our Leadership Team</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Our Leadership Team</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Meet the experienced medical professionals who lead BigMedix with expertise, dedication, and vision.
             </p>
           </div>
           
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
             {teamMembers.map((member, index) => (
-              <div key={index} className="bg-white rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden group hover:-translate-y-2">
+              <div key={index} className="bg-[#FAFAFA] rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden group hover:-translate-y-2">
                 <div className="relative overflow-hidden">
                   <img
                     src={member.image}
@@ -255,12 +255,12 @@ const AboutPage = () => {
                 </div>
                 
                 <div className="p-6">
-                  <h3 className="text-xl font-bold text-gray-900 mb-2">{member.name}</h3>
+                  <h3 className="text-xl font-bold text-[#000000] mb-2">{member.name}</h3>
                   <div className="text-blue-600 font-medium mb-2">{member.position}</div>
-                  <div className="text-sm text-gray-600 mb-3">
+                  <div className="text-sm text-[#4A4A4A] mb-3">
                     {member.experience} • {member.education}
                   </div>
-                  <p className="text-gray-600 text-sm leading-relaxed">{member.bio}</p>
+                  <p className="text-[#4A4A4A] text-sm leading-relaxed">{member.bio}</p>
                 </div>
               </div>
             ))}
@@ -269,7 +269,7 @@ const AboutPage = () => {
       </section>
 
       {/* Statistics */}
-      <section ref={sectionRef} className="py-20 bg-gradient-to-br from-blue-600 to-blue-700 text-white">
+      <section ref={sectionRef} className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white">
         <div className="container mx-auto px-4">
           <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
             {[
@@ -279,7 +279,7 @@ const AboutPage = () => {
               { icon: MapPin, number: `${counters.locations}`, label: 'Convenient Locations', color: 'text-orange-400' }
             ].map((stat, index) => (
               <div key={index} className="text-center group cursor-pointer">
-                <div className="w-20 h-20 bg-white/10 backdrop-blur-sm rounded-3xl flex items-center justify-center mx-auto mb-4 group-hover:bg-white/20 transition-all duration-300 group-hover:scale-110">
+                <div className="w-20 h-20 bg-[#FAFAFA]/10 backdrop-blur-sm rounded-3xl flex items-center justify-center mx-auto mb-4 group-hover:bg-[#FAFAFA]/20 transition-all duration-300 group-hover:scale-110">
                   <stat.icon className={stat.color} size={36} />
                 </div>
                 <div className="text-4xl font-bold mb-2 group-hover:text-orange-300 transition-colors">
@@ -298,15 +298,15 @@ const AboutPage = () => {
       <section className="py-20 bg-gray-50">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Our Locations</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Our Locations</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Conveniently located throughout the city to serve you better with comprehensive healthcare services.
             </p>
           </div>
           
           <div className="grid md:grid-cols-3 gap-8">
             {locations.map((location, index) => (
-              <div key={index} className="bg-white rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden group hover:-translate-y-2">
+              <div key={index} className="bg-[#FAFAFA] rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden group hover:-translate-y-2">
                 <div className="relative overflow-hidden">
                   <img
                     src={location.image}
@@ -317,18 +317,18 @@ const AboutPage = () => {
                 </div>
                 
                 <div className="p-6">
-                  <h3 className="text-xl font-bold text-gray-900 mb-3">{location.name}</h3>
+                  <h3 className="text-xl font-bold text-[#000000] mb-3">{location.name}</h3>
                   <div className="flex items-start space-x-2 mb-3">
                     <MapPin className="text-blue-600 mt-1" size={16} />
-                    <span className="text-gray-600">{location.address}</span>
+                    <span className="text-[#4A4A4A]">{location.address}</span>
                   </div>
                   <div className="flex items-center space-x-2 mb-4">
                     <Clock className="text-green-600" size={16} />
-                    <span className="text-gray-600">{location.phone}</span>
+                    <span className="text-[#4A4A4A]">{location.phone}</span>
                   </div>
                   
                   <div className="space-y-2">
-                    <div className="text-sm font-medium text-gray-900">Services Available:</div>
+                    <div className="text-sm font-medium text-[#000000]">Services Available:</div>
                     <div className="flex flex-wrap gap-2">
                       {location.services.map((service, serviceIndex) => (
                         <span key={serviceIndex} className="bg-blue-50 text-blue-600 px-3 py-1 rounded-full text-xs font-medium">
@@ -345,11 +345,11 @@ const AboutPage = () => {
       </section>
 
       {/* Certifications */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Certifications & Affiliations</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Certifications & Affiliations</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Our commitment to excellence is recognized by leading healthcare organizations and accreditation bodies.
             </p>
           </div>
@@ -367,7 +367,7 @@ const AboutPage = () => {
             ].map((cert, index) => (
               <div key={index} className="bg-gray-50 rounded-2xl p-6 text-center hover:bg-blue-50 transition-colors duration-300 group">
                 <Award className="text-blue-600 mx-auto mb-4 group-hover:text-blue-700 transition-colors" size={32} />
-                <div className="font-medium text-gray-900 group-hover:text-blue-700 transition-colors">{cert}</div>
+                <div className="font-medium text-[#000000] group-hover:text-blue-700 transition-colors">{cert}</div>
               </div>
             ))}
           </div>

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -97,9 +97,9 @@ const BlogPage = () => {
   return (
     <div className="pt-32">
       {/* Hero Section */}
-      <section className="py-20 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white relative overflow-hidden">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white relative overflow-hidden">
         <div className="absolute inset-0 opacity-10">
-          <div className="absolute top-20 left-20 w-64 h-64 bg-white rounded-full blur-3xl"></div>
+          <div className="absolute top-20 left-20 w-64 h-64 bg-[#FAFAFA] rounded-full blur-3xl"></div>
           <div className="absolute bottom-20 right-20 w-64 h-64 bg-orange-500 rounded-full blur-3xl"></div>
         </div>
         
@@ -107,7 +107,7 @@ const BlogPage = () => {
           <div className="text-center mb-16">
             <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
               Health
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-400 to-red-400 block">
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#FA6F42] to-[#F8753D] block">
                 Blog
               </span>
             </h1>
@@ -119,7 +119,7 @@ const BlogPage = () => {
       </section>
 
       {/* Search and Filter */}
-      <section className="py-12 bg-white border-b">
+      <section className="py-12 bg-[#FAFAFA] border-b">
         <div className="container mx-auto px-4">
           <div className="flex flex-col md:flex-row gap-6 items-center justify-between">
             <div className="relative flex-1 max-w-md">
@@ -141,7 +141,7 @@ const BlogPage = () => {
                   className={`px-4 py-2 rounded-full text-sm font-medium transition-all duration-300 ${
                     selectedCategory === category
                       ? 'bg-blue-600 text-white shadow-lg'
-                      : 'bg-gray-100 text-gray-600 hover:bg-blue-50 hover:text-blue-600'
+                      : 'bg-gray-100 text-[#4A4A4A] hover:bg-blue-50 hover:text-blue-600'
                   }`}
                 >
                   {category === 'all' ? 'All Categories' : category}
@@ -157,12 +157,12 @@ const BlogPage = () => {
         <section className="py-16 bg-gray-50">
           <div className="container mx-auto px-4">
             <div className="mb-8">
-              <span className="bg-gradient-to-r from-orange-500 to-red-500 text-white px-4 py-2 rounded-full text-sm font-semibold">
+              <span className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-4 py-2 rounded-full text-sm font-semibold">
                 Featured Article
               </span>
             </div>
             
-            <div className="bg-white rounded-3xl shadow-xl overflow-hidden hover:shadow-2xl transition-all duration-300">
+            <div className="bg-[#FAFAFA] rounded-3xl shadow-xl overflow-hidden hover:shadow-2xl transition-all duration-300">
               <div className="grid lg:grid-cols-2 gap-0">
                 <div className="relative overflow-hidden">
                   <ImageWithFallback
@@ -194,17 +194,17 @@ const BlogPage = () => {
                     </div>
                   </div>
                   
-                  <h2 className="text-3xl font-bold text-gray-900 mb-4 leading-tight">
+                  <h2 className="text-3xl font-bold text-[#000000] mb-4 leading-tight">
                     {featuredPost.title}
                   </h2>
                   
-                  <p className="text-gray-600 leading-relaxed mb-6">
+                  <p className="text-[#4A4A4A] leading-relaxed mb-6">
                     {featuredPost.excerpt}
                   </p>
                   
                   <Link
                     to={`/blog/${featuredPost.slug}`}
-                    className="inline-flex items-center space-x-2 bg-gradient-to-r from-blue-600 to-blue-700 text-white px-6 py-3 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105 w-fit"
+                    className="inline-flex items-center space-x-2 bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-6 py-3 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105 w-fit"
                   >
                     <span>Read Full Article</span>
                     <ArrowRight size={20} />
@@ -217,11 +217,11 @@ const BlogPage = () => {
       )}
 
       {/* Blog Grid */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
             {regularPosts.map((post) => (
-              <article key={post.id} className="bg-white rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden group hover:-translate-y-2">
+              <article key={post.id} className="bg-[#FAFAFA] rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden group hover:-translate-y-2">
                 <div className="relative overflow-hidden">
                   <ImageWithFallback
                     src={post.image}
@@ -248,11 +248,11 @@ const BlogPage = () => {
                     </div>
                   </div>
                   
-                  <h3 className="text-xl font-bold text-gray-900 mb-3 leading-tight group-hover:text-blue-600 transition-colors">
+                  <h3 className="text-xl font-bold text-[#000000] mb-3 leading-tight group-hover:text-blue-600 transition-colors">
                     {post.title}
                   </h3>
                   
-                  <p className="text-gray-600 leading-relaxed mb-4 text-sm">
+                  <p className="text-[#4A4A4A] leading-relaxed mb-4 text-sm">
                     {post.excerpt}
                   </p>
                   
@@ -280,15 +280,15 @@ const BlogPage = () => {
               <div className="text-gray-400 mb-4">
                 <Search size={64} className="mx-auto" />
               </div>
-              <h3 className="text-2xl font-bold text-gray-900 mb-2">No articles found</h3>
-              <p className="text-gray-600">Try adjusting your search terms or category filter.</p>
+              <h3 className="text-2xl font-bold text-[#000000] mb-2">No articles found</h3>
+              <p className="text-[#4A4A4A]">Try adjusting your search terms or category filter.</p>
             </div>
           )}
         </div>
       </section>
 
       {/* Newsletter Signup */}
-      <section className="py-20 bg-gradient-to-br from-blue-600 to-blue-700 text-white">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white">
         <div className="container mx-auto px-4 text-center">
           <h2 className="text-4xl font-bold mb-6">Stay Updated with Health Tips</h2>
           <p className="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
@@ -299,9 +299,9 @@ const BlogPage = () => {
             <input
               type="email"
               placeholder="Enter your email address"
-              className="flex-1 px-6 py-4 rounded-full text-gray-900 focus:outline-none focus:ring-4 focus:ring-blue-300"
+              className="flex-1 px-6 py-4 rounded-full text-[#000000] focus:outline-none focus:ring-4 focus:ring-blue-300"
             />
-            <button className="bg-gradient-to-r from-orange-500 to-red-500 text-white px-8 py-4 rounded-full hover:from-orange-600 hover:to-red-600 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105">
+            <button className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-8 py-4 rounded-full hover:opacity-90 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105">
               Subscribe
             </button>
           </div>

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -102,7 +102,7 @@ const BlogPost = () => {
       </div>
 
       {/* Article Header */}
-      <section className="py-16 bg-white">
+      <section className="py-16 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto">
             <div className="mb-8">
@@ -111,11 +111,11 @@ const BlogPost = () => {
               </span>
             </div>
             
-            <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-6 leading-tight">
+            <h1 className="text-4xl md:text-5xl font-bold text-[#000000] mb-6 leading-tight">
               {post.title}
             </h1>
             
-            <div className="flex flex-wrap items-center gap-6 text-gray-600 mb-8">
+            <div className="flex flex-wrap items-center gap-6 text-[#4A4A4A] mb-8">
               <div className="flex items-center space-x-2">
                 <User size={20} />
                 <span className="font-medium">{post.author}</span>
@@ -140,11 +140,11 @@ const BlogPost = () => {
                 <Heart size={18} />
                 <span>Like</span>
               </button>
-              <button className="flex items-center space-x-2 bg-gray-50 text-gray-600 px-4 py-2 rounded-full hover:bg-gray-100 transition-colors">
+              <button className="flex items-center space-x-2 bg-gray-50 text-[#4A4A4A] px-4 py-2 rounded-full hover:bg-gray-100 transition-colors">
                 <Bookmark size={18} />
                 <span>Save</span>
               </button>
-              <button className="flex items-center space-x-2 bg-gray-50 text-gray-600 px-4 py-2 rounded-full hover:bg-gray-100 transition-colors">
+              <button className="flex items-center space-x-2 bg-gray-50 text-[#4A4A4A] px-4 py-2 rounded-full hover:bg-gray-100 transition-colors">
                 <Share2 size={18} />
                 <span>Share</span>
               </button>
@@ -170,11 +170,11 @@ const BlogPost = () => {
       </section>
 
       {/* Article Content */}
-      <section className="py-16 bg-white">
+      <section className="py-16 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto">
             <div 
-              className="prose prose-lg max-w-none prose-headings:text-gray-900 prose-headings:font-bold prose-p:text-gray-700 prose-p:leading-relaxed prose-li:text-gray-700 prose-strong:text-gray-900 prose-a:text-blue-600 prose-a:no-underline hover:prose-a:underline"
+              className="prose prose-lg max-w-none prose-headings:text-[#000000] prose-headings:font-bold prose-p:text-gray-700 prose-p:leading-relaxed prose-li:text-gray-700 prose-strong:text-[#000000] prose-a:text-blue-600 prose-a:no-underline hover:prose-a:underline"
               dangerouslySetInnerHTML={{ __html: post.content }}
             />
           </div>
@@ -185,7 +185,7 @@ const BlogPost = () => {
       <section className="py-16 bg-gray-50">
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto">
-            <div className="bg-white rounded-3xl p-8 shadow-lg">
+            <div className="bg-[#FAFAFA] rounded-3xl p-8 shadow-lg">
               <div className="flex items-start space-x-6">
                 <ImageWithFallback
                   src="https://images.unsplash.com/photo-1559839734-2b71ea197ec2?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80"
@@ -193,9 +193,9 @@ const BlogPost = () => {
                   className="w-24 h-24 rounded-full object-cover"
                 />
                 <div className="flex-1">
-                  <h3 className="text-2xl font-bold text-gray-900 mb-2">{post.author}</h3>
+                  <h3 className="text-2xl font-bold text-[#000000] mb-2">{post.author}</h3>
                   <div className="text-blue-600 font-medium mb-4">Chief Cardiologist at BigMedix</div>
-                  <p className="text-gray-600 leading-relaxed">
+                  <p className="text-[#4A4A4A] leading-relaxed">
                     Dr. Sarah Johnson is a board-certified cardiologist with over 15 years of experience in cardiovascular medicine. 
                     She specializes in preventive cardiology and has published numerous research papers on heart disease prevention. 
                     Dr. Johnson is passionate about patient education and helping individuals achieve optimal heart health through 
@@ -209,10 +209,10 @@ const BlogPost = () => {
       </section>
 
       {/* Related Articles */}
-      <section className="py-16 bg-white">
+      <section className="py-16 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto">
-            <h2 className="text-3xl font-bold text-gray-900 mb-8">Related Articles</h2>
+            <h2 className="text-3xl font-bold text-[#000000] mb-8">Related Articles</h2>
             
             <div className="grid md:grid-cols-2 gap-8">
               {[
@@ -232,7 +232,7 @@ const BlogPost = () => {
                 <Link
                   key={index}
                   to={`/blog/${article.slug}`}
-                  className="group bg-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden hover:-translate-y-2"
+                  className="group bg-[#FAFAFA] rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden hover:-translate-y-2"
                 >
                   <div className="relative overflow-hidden">
                     <ImageWithFallback
@@ -242,10 +242,10 @@ const BlogPost = () => {
                     />
                   </div>
                   <div className="p-6">
-                    <h3 className="text-xl font-bold text-gray-900 mb-3 group-hover:text-blue-600 transition-colors">
+                    <h3 className="text-xl font-bold text-[#000000] mb-3 group-hover:text-blue-600 transition-colors">
                       {article.title}
                     </h3>
-                    <p className="text-gray-600 leading-relaxed">
+                    <p className="text-[#4A4A4A] leading-relaxed">
                       {article.excerpt}
                     </p>
                   </div>

--- a/src/pages/Careers.tsx
+++ b/src/pages/Careers.tsx
@@ -165,9 +165,9 @@ const Careers = () => {
   return (
     <div className="pt-32">
       {/* Hero Section */}
-      <section className="py-20 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white relative overflow-hidden">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white relative overflow-hidden">
         <div className="absolute inset-0 opacity-10">
-          <div className="absolute top-20 left-20 w-64 h-64 bg-white rounded-full blur-3xl"></div>
+          <div className="absolute top-20 left-20 w-64 h-64 bg-[#FAFAFA] rounded-full blur-3xl"></div>
           <div className="absolute bottom-20 right-20 w-64 h-64 bg-orange-500 rounded-full blur-3xl"></div>
         </div>
         
@@ -175,7 +175,7 @@ const Careers = () => {
           <div className="text-center mb-16">
             <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
               Join Our
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-400 to-red-400 block">
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#FA6F42] to-[#F8753D] block">
                 Healthcare Team
               </span>
             </h1>
@@ -187,23 +187,23 @@ const Careers = () => {
       </section>
 
       {/* Why Work With Us */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Why Choose BigMedix?</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Why Choose BigMedix?</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Join a team that values innovation, collaboration, and making a real difference in patients' lives every day.
             </p>
           </div>
 
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
             {benefits.map((benefit, index) => (
-              <div key={index} className="bg-white rounded-3xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 text-center group hover:-translate-y-2">
+              <div key={index} className="bg-[#FAFAFA] rounded-3xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 text-center group hover:-translate-y-2">
                 <div className={`w-20 h-20 bg-gradient-to-br ${benefit.color} rounded-3xl flex items-center justify-center mx-auto mb-6 group-hover:scale-110 transition-transform duration-300`}>
                   <benefit.icon className="text-white" size={36} />
                 </div>
-                <h3 className="text-xl font-bold text-gray-900 mb-4">{benefit.title}</h3>
-                <p className="text-gray-600 leading-relaxed">{benefit.description}</p>
+                <h3 className="text-xl font-bold text-[#000000] mb-4">{benefit.title}</h3>
+                <p className="text-[#4A4A4A] leading-relaxed">{benefit.description}</p>
               </div>
             ))}
           </div>
@@ -258,7 +258,7 @@ const Careers = () => {
             </div>
             
             <div className="text-center">
-              <p className="text-gray-600">
+              <p className="text-[#4A4A4A]">
                 Showing {filteredJobs.length} of {jobOpenings.length} available positions
               </p>
             </div>
@@ -273,12 +273,12 @@ const Careers = () => {
             {filteredJobs.length > 0 ? (
               <div className="space-y-6">
                 {filteredJobs.map((job) => (
-                  <div key={job.id} className="bg-white rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden group hover:-translate-y-1">
+                  <div key={job.id} className="bg-[#FAFAFA] rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden group hover:-translate-y-1">
                     <div className="p-8">
                       <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between mb-6">
                         <div className="flex-1">
                           <div className="flex items-center space-x-3 mb-2">
-                            <h3 className="text-2xl font-bold text-gray-900 group-hover:text-blue-600 transition-colors">
+                            <h3 className="text-2xl font-bold text-[#000000] group-hover:text-blue-600 transition-colors">
                               {job.title}
                             </h3>
                             <span className={`px-3 py-1 rounded-full text-sm font-medium ${
@@ -290,7 +290,7 @@ const Careers = () => {
                             </span>
                           </div>
                           
-                          <div className="flex flex-wrap items-center gap-4 text-gray-600 mb-4">
+                          <div className="flex flex-wrap items-center gap-4 text-[#4A4A4A] mb-4">
                             <div className="flex items-center space-x-1">
                               <Briefcase size={16} />
                               <span>{job.department}</span>
@@ -311,7 +311,7 @@ const Careers = () => {
                         </div>
                         
                         <div className="flex flex-col sm:flex-row gap-3">
-                          <button className="bg-gradient-to-r from-blue-600 to-blue-700 text-white px-6 py-3 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105">
+                          <button className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-6 py-3 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105">
                             Apply Now
                           </button>
                           <button className="border-2 border-blue-600 text-blue-600 px-6 py-3 rounded-full hover:bg-blue-50 transition-all duration-300 font-semibold">
@@ -320,16 +320,16 @@ const Careers = () => {
                         </div>
                       </div>
                       
-                      <p className="text-gray-600 leading-relaxed mb-6">
+                      <p className="text-[#4A4A4A] leading-relaxed mb-6">
                         {job.description}
                       </p>
                       
                       <div className="grid md:grid-cols-2 gap-6">
                         <div>
-                          <h4 className="font-bold text-gray-900 mb-3">Requirements:</h4>
+                          <h4 className="font-bold text-[#000000] mb-3">Requirements:</h4>
                           <ul className="space-y-1">
                             {job.requirements.map((req, index) => (
-                              <li key={index} className="flex items-center text-sm text-gray-600">
+                              <li key={index} className="flex items-center text-sm text-[#4A4A4A]">
                                 <div className="w-2 h-2 bg-blue-600 rounded-full mr-3"></div>
                                 {req}
                               </li>
@@ -338,7 +338,7 @@ const Careers = () => {
                         </div>
                         
                         <div>
-                          <h4 className="font-bold text-gray-900 mb-3">Benefits:</h4>
+                          <h4 className="font-bold text-[#000000] mb-3">Benefits:</h4>
                           <div className="flex flex-wrap gap-2">
                             {job.benefits.map((benefit, index) => (
                               <span key={index} className="bg-blue-50 text-blue-600 px-3 py-1 rounded-full text-sm font-medium">
@@ -366,8 +366,8 @@ const Careers = () => {
                 <div className="text-gray-400 mb-4">
                   <Briefcase size={64} className="mx-auto" />
                 </div>
-                <h3 className="text-2xl font-bold text-gray-900 mb-2">No positions found</h3>
-                <p className="text-gray-600 mb-6">Try adjusting your search criteria or check back later for new openings.</p>
+                <h3 className="text-2xl font-bold text-[#000000] mb-2">No positions found</h3>
+                <p className="text-[#4A4A4A] mb-6">Try adjusting your search criteria or check back later for new openings.</p>
                 <button 
                   onClick={() => {
                     setSearchTerm('');
@@ -385,11 +385,11 @@ const Careers = () => {
       </section>
 
       {/* Employee Testimonials */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">What Our Team Says</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">What Our Team Says</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Hear from our employees about their experience working at BigMedix and why they love being part of our healthcare family.
             </p>
           </div>
@@ -422,11 +422,11 @@ const Careers = () => {
                     alt={testimonial.name}
                     className="w-20 h-20 rounded-full object-cover mx-auto mb-4 border-4 border-white shadow-lg"
                   />
-                  <h3 className="text-xl font-bold text-gray-900">{testimonial.name}</h3>
+                  <h3 className="text-xl font-bold text-[#000000]">{testimonial.name}</h3>
                   <div className="text-blue-600 font-medium">{testimonial.position}</div>
                 </div>
                 
-                <blockquote className="text-gray-600 leading-relaxed italic">
+                <blockquote className="text-[#4A4A4A] leading-relaxed italic">
                   "{testimonial.quote}"
                 </blockquote>
               </div>
@@ -439,8 +439,8 @@ const Careers = () => {
       <section className="py-20 bg-gray-50">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Application Process</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Application Process</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Our streamlined application process is designed to be simple and efficient while ensuring we find the best candidates for our team.
             </p>
           </div>
@@ -472,8 +472,8 @@ const Careers = () => {
                 <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-600 rounded-full flex items-center justify-center mx-auto mb-6 text-white text-2xl font-bold shadow-lg">
                   {step.step}
                 </div>
-                <h3 className="text-xl font-bold text-gray-900 mb-4">{step.title}</h3>
-                <p className="text-gray-600 leading-relaxed">{step.description}</p>
+                <h3 className="text-xl font-bold text-[#000000] mb-4">{step.title}</h3>
+                <p className="text-[#4A4A4A] leading-relaxed">{step.description}</p>
               </div>
             ))}
           </div>
@@ -481,7 +481,7 @@ const Careers = () => {
       </section>
 
       {/* Call to Action */}
-      <section className="py-20 bg-gradient-to-br from-blue-600 to-blue-700 text-white">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white">
         <div className="container mx-auto px-4 text-center">
           <h2 className="text-4xl font-bold mb-6">Ready to Start Your Career with Us?</h2>
           <p className="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
@@ -489,10 +489,10 @@ const Careers = () => {
           </p>
           
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <button className="bg-gradient-to-r from-orange-500 to-red-500 text-white px-8 py-4 rounded-full hover:from-orange-600 hover:to-red-600 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
+            <button className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-8 py-4 rounded-full hover:opacity-90 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
               View All Openings
             </button>
-            <button className="bg-white/20 backdrop-blur-sm text-white px-8 py-4 rounded-full hover:bg-white/30 transition-all duration-300 font-semibold border border-white/30">
+            <button className="bg-[#FAFAFA]/20 backdrop-blur-sm text-white px-8 py-4 rounded-full hover:bg-[#FAFAFA]/30 transition-all duration-300 font-semibold border border-white/30">
               Contact HR Team
             </button>
           </div>

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -80,9 +80,9 @@ const ContactPage = () => {
   return (
     <div className="pt-32">
       {/* Hero Section */}
-      <section className="py-20 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white relative overflow-hidden">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white relative overflow-hidden">
         <div className="absolute inset-0 opacity-10">
-          <div className="absolute top-20 left-20 w-64 h-64 bg-white rounded-full blur-3xl"></div>
+          <div className="absolute top-20 left-20 w-64 h-64 bg-[#FAFAFA] rounded-full blur-3xl"></div>
           <div className="absolute bottom-20 right-20 w-64 h-64 bg-orange-500 rounded-full blur-3xl"></div>
         </div>
         
@@ -90,7 +90,7 @@ const ContactPage = () => {
           <div className="text-center mb-16">
             <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
               Contact
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-400 to-red-400 block">
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#FA6F42] to-[#F8753D] block">
                 BigMedix
               </span>
             </h1>
@@ -102,11 +102,11 @@ const ContactPage = () => {
       </section>
 
       {/* Quick Contact Cards */}
-      <section className="py-16 bg-white">
+      <section className="py-16 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="grid md:grid-cols-3 gap-8 mb-16">
             <div className="bg-gradient-to-br from-red-500 to-red-600 rounded-3xl p-8 text-white shadow-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-2">
-              <div className="w-16 h-16 bg-white/20 rounded-2xl flex items-center justify-center mb-6">
+              <div className="w-16 h-16 bg-[#FAFAFA]/20 rounded-2xl flex items-center justify-center mb-6">
                 <Phone className="text-white" size={32} />
               </div>
               <h3 className="text-2xl font-bold mb-4">Emergency Care</h3>
@@ -116,7 +116,7 @@ const ContactPage = () => {
             </div>
 
             <div className="bg-gradient-to-br from-blue-500 to-blue-600 rounded-3xl p-8 text-white shadow-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-2">
-              <div className="w-16 h-16 bg-white/20 rounded-2xl flex items-center justify-center mb-6">
+              <div className="w-16 h-16 bg-[#FAFAFA]/20 rounded-2xl flex items-center justify-center mb-6">
                 <Calendar className="text-white" size={32} />
               </div>
               <h3 className="text-2xl font-bold mb-4">Appointments</h3>
@@ -126,12 +126,12 @@ const ContactPage = () => {
             </div>
 
             <div className="bg-gradient-to-br from-green-500 to-green-600 rounded-3xl p-8 text-white shadow-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-2">
-              <div className="w-16 h-16 bg-white/20 rounded-2xl flex items-center justify-center mb-6">
+              <div className="w-16 h-16 bg-[#FAFAFA]/20 rounded-2xl flex items-center justify-center mb-6">
                 <MessageCircle className="text-white" size={32} />
               </div>
               <h3 className="text-2xl font-bold mb-4">Patient Portal</h3>
               <p className="text-green-100 mb-6">Access records and message your doctor</p>
-              <button className="bg-white text-green-600 px-6 py-3 rounded-full font-bold hover:bg-green-50 transition-colors">
+              <button className="bg-[#FAFAFA] text-green-600 px-6 py-3 rounded-full font-bold hover:bg-green-50 transition-colors">
                 Login Portal
               </button>
             </div>
@@ -144,10 +144,10 @@ const ContactPage = () => {
         <div className="container mx-auto px-4">
           <div className="grid lg:grid-cols-2 gap-16">
             {/* Contact Form */}
-            <div className="bg-white rounded-3xl p-8 shadow-xl">
+            <div className="bg-[#FAFAFA] rounded-3xl p-8 shadow-xl">
               <div className="flex items-center mb-8">
                 <Send className="text-blue-600 mr-4" size={32} />
-                <h2 className="text-3xl font-bold text-gray-900">Send us a Message</h2>
+                <h2 className="text-3xl font-bold text-[#000000]">Send us a Message</h2>
               </div>
               
               <form className="space-y-6">
@@ -253,7 +253,7 @@ const ContactPage = () => {
 
                 <button
                   type="submit"
-                  className="w-full bg-gradient-to-r from-blue-600 to-blue-700 text-white py-4 rounded-2xl hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-bold flex items-center justify-center space-x-3 shadow-xl hover:shadow-2xl transform hover:scale-105"
+                  className="w-full bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white py-4 rounded-2xl hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-bold flex items-center justify-center space-x-3 shadow-xl hover:shadow-2xl transform hover:scale-105"
                 >
                   <Send size={24} />
                   <span>Send Message</span>
@@ -263,8 +263,8 @@ const ContactPage = () => {
 
             {/* Contact Information */}
             <div className="space-y-8">
-              <div className="bg-white rounded-3xl p-8 shadow-xl">
-                <h3 className="text-2xl font-bold text-gray-900 mb-6">Get in Touch</h3>
+              <div className="bg-[#FAFAFA] rounded-3xl p-8 shadow-xl">
+                <h3 className="text-2xl font-bold text-[#000000] mb-6">Get in Touch</h3>
                 
                 <div className="space-y-6">
                   <div className="flex items-start space-x-4">
@@ -272,8 +272,8 @@ const ContactPage = () => {
                       <Phone className="text-blue-600" size={24} />
                     </div>
                     <div>
-                      <h4 className="font-bold text-gray-900 mb-2">Phone</h4>
-                      <p className="text-gray-600 mb-2">Main: +1 (555) 123-4567</p>
+                      <h4 className="font-bold text-[#000000] mb-2">Phone</h4>
+                      <p className="text-[#4A4A4A] mb-2">Main: +1 (555) 123-4567</p>
                       <p className="text-red-600 font-medium">Emergency: +1 (555) 911-HELP</p>
                     </div>
                   </div>
@@ -283,9 +283,9 @@ const ContactPage = () => {
                       <Mail className="text-green-600" size={24} />
                     </div>
                     <div>
-                      <h4 className="font-bold text-gray-900 mb-2">Email</h4>
-                      <p className="text-gray-600 mb-1">info@bigmedix.com</p>
-                      <p className="text-gray-600">appointments@bigmedix.com</p>
+                      <h4 className="font-bold text-[#000000] mb-2">Email</h4>
+                      <p className="text-[#4A4A4A] mb-1">info@bigmedix.com</p>
+                      <p className="text-[#4A4A4A]">appointments@bigmedix.com</p>
                     </div>
                   </div>
 
@@ -294,8 +294,8 @@ const ContactPage = () => {
                       <MapPin className="text-orange-600" size={24} />
                     </div>
                     <div>
-                      <h4 className="font-bold text-gray-900 mb-2">Main Location</h4>
-                      <p className="text-gray-600">123 Medical Plaza<br />Health City, HC 12345</p>
+                      <h4 className="font-bold text-[#000000] mb-2">Main Location</h4>
+                      <p className="text-[#4A4A4A]">123 Medical Plaza<br />Health City, HC 12345</p>
                     </div>
                   </div>
 
@@ -304,9 +304,9 @@ const ContactPage = () => {
                       <Clock className="text-purple-600" size={24} />
                     </div>
                     <div>
-                      <h4 className="font-bold text-gray-900 mb-2">Hours</h4>
-                      <p className="text-gray-600 mb-1">Mon-Fri: 8:00 AM - 6:00 PM</p>
-                      <p className="text-gray-600 mb-1">Saturday: 9:00 AM - 4:00 PM</p>
+                      <h4 className="font-bold text-[#000000] mb-2">Hours</h4>
+                      <p className="text-[#4A4A4A] mb-1">Mon-Fri: 8:00 AM - 6:00 PM</p>
+                      <p className="text-[#4A4A4A] mb-1">Saturday: 9:00 AM - 4:00 PM</p>
                       <p className="text-red-600 font-medium">Emergency: 24/7</p>
                     </div>
                   </div>
@@ -314,15 +314,15 @@ const ContactPage = () => {
               </div>
 
               {/* Department Directory */}
-              <div className="bg-white rounded-3xl p-8 shadow-xl">
-                <h3 className="text-2xl font-bold text-gray-900 mb-6">Department Directory</h3>
+              <div className="bg-[#FAFAFA] rounded-3xl p-8 shadow-xl">
+                <h3 className="text-2xl font-bold text-[#000000] mb-6">Department Directory</h3>
                 
                 <div className="space-y-4">
                   {departments.map((dept, index) => (
                     <div key={index} className="flex items-center justify-between p-4 bg-gray-50 rounded-2xl hover:bg-blue-50 transition-colors">
                       <div>
-                        <div className="font-medium text-gray-900">{dept.name}</div>
-                        <div className="text-sm text-gray-600">Ext. {dept.ext}</div>
+                        <div className="font-medium text-[#000000]">{dept.name}</div>
+                        <div className="text-sm text-[#4A4A4A]">Ext. {dept.ext}</div>
                       </div>
                       <div className="text-blue-600 font-medium">{dept.phone}</div>
                     </div>
@@ -335,18 +335,18 @@ const ContactPage = () => {
       </section>
 
       {/* Locations */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Our Locations</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Our Locations</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Visit us at any of our convenient locations throughout the city. Each facility offers specialized services and expert care.
             </p>
           </div>
           
           <div className="grid lg:grid-cols-3 gap-8">
             {locations.map((location, index) => (
-              <div key={index} className="bg-white rounded-3xl shadow-xl hover:shadow-2xl transition-all duration-300 overflow-hidden group hover:-translate-y-2">
+              <div key={index} className="bg-[#FAFAFA] rounded-3xl shadow-xl hover:shadow-2xl transition-all duration-300 overflow-hidden group hover:-translate-y-2">
                 <div className="relative overflow-hidden">
                   <img
                     src={location.image}
@@ -363,47 +363,47 @@ const ContactPage = () => {
                   <div className="flex items-start space-x-3">
                     <MapPin className="text-blue-600 mt-1" size={20} />
                     <div>
-                      <div className="font-medium text-gray-900">Address</div>
-                      <div className="text-gray-600">{location.address}</div>
+                      <div className="font-medium text-[#000000]">Address</div>
+                      <div className="text-[#4A4A4A]">{location.address}</div>
                     </div>
                   </div>
                   
                   <div className="flex items-start space-x-3">
                     <Phone className="text-green-600 mt-1" size={20} />
                     <div>
-                      <div className="font-medium text-gray-900">Contact</div>
-                      <div className="text-gray-600">{location.phone}</div>
-                      <div className="text-gray-600">{location.email}</div>
+                      <div className="font-medium text-[#000000]">Contact</div>
+                      <div className="text-[#4A4A4A]">{location.phone}</div>
+                      <div className="text-[#4A4A4A]">{location.email}</div>
                     </div>
                   </div>
                   
                   <div className="flex items-start space-x-3">
                     <Clock className="text-orange-600 mt-1" size={20} />
                     <div>
-                      <div className="font-medium text-gray-900">Hours</div>
-                      <div className="text-gray-600">{location.hours.weekdays}</div>
-                      <div className="text-gray-600">{location.hours.weekend}</div>
+                      <div className="font-medium text-[#000000]">Hours</div>
+                      <div className="text-[#4A4A4A]">{location.hours.weekdays}</div>
+                      <div className="text-[#4A4A4A]">{location.hours.weekend}</div>
                     </div>
                   </div>
 
                   <div className="flex items-start space-x-3">
                     <Car className="text-purple-600 mt-1" size={20} />
                     <div>
-                      <div className="font-medium text-gray-900">Parking</div>
-                      <div className="text-gray-600">{location.parking}</div>
+                      <div className="font-medium text-[#000000]">Parking</div>
+                      <div className="text-[#4A4A4A]">{location.parking}</div>
                     </div>
                   </div>
 
                   <div className="flex items-start space-x-3">
                     <Bus className="text-indigo-600 mt-1" size={20} />
                     <div>
-                      <div className="font-medium text-gray-900">Public Transport</div>
-                      <div className="text-gray-600 text-sm">{location.publicTransport}</div>
+                      <div className="font-medium text-[#000000]">Public Transport</div>
+                      <div className="text-[#4A4A4A] text-sm">{location.publicTransport}</div>
                     </div>
                   </div>
                   
                   <div className="pt-4 border-t border-gray-200">
-                    <div className="text-sm font-medium text-gray-900 mb-3">Services Available:</div>
+                    <div className="text-sm font-medium text-[#000000] mb-3">Services Available:</div>
                     <div className="flex flex-wrap gap-2">
                       {location.services.map((service, serviceIndex) => (
                         <span key={serviceIndex} className="bg-blue-50 text-blue-600 px-3 py-1 rounded-full text-xs font-medium">
@@ -413,7 +413,7 @@ const ContactPage = () => {
                     </div>
                   </div>
 
-                  <button className="w-full bg-gradient-to-r from-blue-600 to-blue-700 text-white py-3 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105 flex items-center justify-center space-x-2">
+                  <button className="w-full bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white py-3 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105 flex items-center justify-center space-x-2">
                     <Navigation size={18} />
                     <span>Get Directions</span>
                   </button>
@@ -428,8 +428,8 @@ const ContactPage = () => {
       <section className="py-20 bg-gray-50">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Frequently Asked Questions</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Frequently Asked Questions</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Find quick answers to common questions about our services, appointments, and policies.
             </p>
           </div>
@@ -461,9 +461,9 @@ const ContactPage = () => {
                 answer: "We require at least 24 hours notice for appointment cancellations. Late cancellations or no-shows may result in a fee."
               }
             ].map((faq, index) => (
-              <div key={index} className="bg-white rounded-2xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
-                <h3 className="text-lg font-bold text-gray-900 mb-3">{faq.question}</h3>
-                <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+              <div key={index} className="bg-[#FAFAFA] rounded-2xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
+                <h3 className="text-lg font-bold text-[#000000] mb-3">{faq.question}</h3>
+                <p className="text-[#4A4A4A] leading-relaxed">{faq.answer}</p>
               </div>
             ))}
           </div>

--- a/src/pages/DoctorsPage.tsx
+++ b/src/pages/DoctorsPage.tsx
@@ -144,9 +144,9 @@ const DoctorsPage = () => {
   return (
     <div className="pt-32">
       {/* Hero Section */}
-      <section className="py-20 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white relative overflow-hidden">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white relative overflow-hidden">
         <div className="absolute inset-0 opacity-10">
-          <div className="absolute top-20 left-20 w-64 h-64 bg-white rounded-full blur-3xl"></div>
+          <div className="absolute top-20 left-20 w-64 h-64 bg-[#FAFAFA] rounded-full blur-3xl"></div>
           <div className="absolute bottom-20 right-20 w-64 h-64 bg-orange-500 rounded-full blur-3xl"></div>
         </div>
         
@@ -154,7 +154,7 @@ const DoctorsPage = () => {
           <div className="text-center mb-16">
             <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
               Our Expert
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-400 to-red-400 block">
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#FA6F42] to-[#F8753D] block">
                 Doctors
               </span>
             </h1>
@@ -166,7 +166,7 @@ const DoctorsPage = () => {
       </section>
 
       {/* Filter Section */}
-      <section className="py-12 bg-white border-b">
+      <section className="py-12 bg-[#FAFAFA] border-b">
         <div className="container mx-auto px-4">
           <div className="flex flex-wrap justify-center gap-4">
             {specialties.map((specialty) => (
@@ -176,7 +176,7 @@ const DoctorsPage = () => {
                 className={`px-6 py-3 rounded-full text-sm font-medium transition-all duration-300 ${
                   selectedSpecialty === specialty
                     ? 'bg-blue-600 text-white shadow-lg transform scale-105'
-                    : 'bg-gray-100 text-gray-600 hover:bg-blue-50 hover:text-blue-600'
+                    : 'bg-gray-100 text-[#4A4A4A] hover:bg-blue-50 hover:text-blue-600'
                 }`}
               >
                 {specialty === 'all' ? 'All Specialties' : specialty}
@@ -195,7 +195,7 @@ const DoctorsPage = () => {
                 key={index}
                 data-index={index}
                 data-animate="doctor"
-                className={`group bg-white rounded-3xl shadow-xl hover:shadow-2xl transition-all duration-500 overflow-hidden cursor-pointer transform hover:-translate-y-6 ${
+                className={`group bg-[#FAFAFA] rounded-3xl shadow-xl hover:shadow-2xl transition-all duration-500 overflow-hidden cursor-pointer transform hover:-translate-y-6 ${
                   visibleItems.has(index.toString()) 
                     ? 'translate-y-0 opacity-100' 
                     : 'translate-y-8 opacity-0'
@@ -211,24 +211,24 @@ const DoctorsPage = () => {
                   <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-transparent"></div>
                   
                   {/* Rating Badge */}
-                  <div className="absolute top-4 right-4 bg-white/90 backdrop-blur-sm rounded-full px-3 py-2 flex items-center space-x-1 shadow-lg">
+                  <div className="absolute top-4 right-4 bg-[#FAFAFA]/90 backdrop-blur-sm rounded-full px-3 py-2 flex items-center space-x-1 shadow-lg">
                     <Star className="text-yellow-400 fill-current" size={16} />
                     <span className="text-sm font-bold text-gray-800">{doctor.rating}</span>
                   </div>
 
                   {/* Specialty Badge */}
-                  <div className="absolute bottom-4 left-4 bg-gradient-to-r from-blue-600 to-blue-700 text-white px-4 py-2 rounded-full text-sm font-semibold shadow-lg">
+                  <div className="absolute bottom-4 left-4 bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-4 py-2 rounded-full text-sm font-semibold shadow-lg">
                     {doctor.specialty}
                   </div>
                 </div>
                 
                 <div className="p-6 space-y-4">
                   <div>
-                    <h3 className="text-2xl font-bold text-gray-900 mb-2 group-hover:text-blue-600 transition-colors">
+                    <h3 className="text-2xl font-bold text-[#000000] mb-2 group-hover:text-blue-600 transition-colors">
                       {doctor.name}
                     </h3>
                     <div className="text-blue-600 font-medium mb-2">{doctor.position}</div>
-                    <div className="flex items-center space-x-4 text-sm text-gray-600 mb-4">
+                    <div className="flex items-center space-x-4 text-sm text-[#4A4A4A] mb-4">
                       <div className="flex items-center space-x-1">
                         <Calendar size={16} />
                         <span>{doctor.experience}</span>
@@ -241,18 +241,18 @@ const DoctorsPage = () => {
                   </div>
 
                   <div className="space-y-3">
-                    <div className="flex items-center space-x-2 text-sm text-gray-600">
+                    <div className="flex items-center space-x-2 text-sm text-[#4A4A4A]">
                       <GraduationCap size={16} className="text-blue-600" />
                       <span className="font-medium">{doctor.education}</span>
                     </div>
                     
-                    <div className="flex items-center space-x-2 text-sm text-gray-600">
+                    <div className="flex items-center space-x-2 text-sm text-[#4A4A4A]">
                       <Clock size={16} className="text-green-600" />
                       <span>{doctor.availability}</span>
                     </div>
                     
                     <div className="flex items-center justify-between text-sm">
-                      <span className="text-gray-600">{doctor.reviews} patient reviews</span>
+                      <span className="text-[#4A4A4A]">{doctor.reviews} patient reviews</span>
                       <div className="flex items-center space-x-1">
                         {[...Array(5)].map((_, i) => (
                           <Star
@@ -266,7 +266,7 @@ const DoctorsPage = () => {
                   </div>
 
                   <div className="pt-4 border-t border-gray-100">
-                    <div className="text-sm text-gray-600 mb-3">Specialties:</div>
+                    <div className="text-sm text-[#4A4A4A] mb-3">Specialties:</div>
                     <div className="flex flex-wrap gap-2">
                       {doctor.specialties.slice(0, 2).map((specialty, i) => (
                         <span key={i} className="bg-blue-50 text-blue-600 px-3 py-1 rounded-full text-xs font-medium">
@@ -274,7 +274,7 @@ const DoctorsPage = () => {
                         </span>
                       ))}
                       {doctor.specialties.length > 2 && (
-                        <span className="bg-gray-100 text-gray-600 px-3 py-1 rounded-full text-xs font-medium">
+                        <span className="bg-gray-100 text-[#4A4A4A] px-3 py-1 rounded-full text-xs font-medium">
                           +{doctor.specialties.length - 2} more
                         </span>
                       )}
@@ -282,7 +282,7 @@ const DoctorsPage = () => {
                   </div>
 
                   <div className="flex space-x-2">
-                    <button className="flex-1 bg-gradient-to-r from-blue-600 to-blue-700 text-white py-3 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105">
+                    <button className="flex-1 bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white py-3 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105">
                       Book Appointment
                     </button>
                     <button className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center hover:bg-blue-50 transition-colors">
@@ -297,9 +297,9 @@ const DoctorsPage = () => {
       </section>
 
       {/* Doctor Spotlight */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
-          <div className="bg-gradient-to-br from-blue-50 to-white rounded-3xl p-8 lg:p-12 shadow-xl">
+          <div className="bg-[#F4F9F7] rounded-3xl p-8 lg:p-12 shadow-xl">
             <div className="grid lg:grid-cols-2 gap-12 items-center">
               <div className="relative">
                 <img
@@ -307,14 +307,14 @@ const DoctorsPage = () => {
                   alt={doctors[0].name}
                   className="w-full h-96 object-cover rounded-3xl shadow-xl"
                 />
-                <div className="absolute -bottom-6 -right-6 bg-white rounded-2xl p-6 shadow-xl">
+                <div className="absolute -bottom-6 -right-6 bg-[#FAFAFA] rounded-2xl p-6 shadow-xl">
                   <div className="flex items-center space-x-4">
                     <div className="w-12 h-12 bg-gradient-to-br from-blue-500 to-blue-600 rounded-full flex items-center justify-center">
                       <Award className="text-white" size={20} />
                     </div>
                     <div>
                       <div className="font-bold text-gray-800">Chief Cardiologist</div>
-                      <div className="text-sm text-gray-600">Department Head</div>
+                      <div className="text-sm text-[#4A4A4A]">Department Head</div>
                     </div>
                   </div>
                 </div>
@@ -323,18 +323,18 @@ const DoctorsPage = () => {
               <div className="space-y-6">
                 <div>
                   <div className="text-blue-600 font-medium mb-2">Doctor Spotlight</div>
-                  <h3 className="text-4xl font-bold text-gray-900 mb-4">{doctors[0].name}</h3>
-                  <div className="text-xl text-gray-600 mb-6">{doctors[0].position}</div>
+                  <h3 className="text-4xl font-bold text-[#000000] mb-4">{doctors[0].name}</h3>
+                  <div className="text-xl text-[#4A4A4A] mb-6">{doctors[0].position}</div>
                 </div>
                 
-                <p className="text-gray-600 leading-relaxed text-lg">
+                <p className="text-[#4A4A4A] leading-relaxed text-lg">
                   {doctors[0].bio}
                 </p>
                 
                 <div className="grid md:grid-cols-2 gap-6">
                   <div>
-                    <h4 className="font-bold text-gray-900 mb-3">Education & Certifications</h4>
-                    <ul className="space-y-2 text-sm text-gray-600">
+                    <h4 className="font-bold text-[#000000] mb-3">Education & Certifications</h4>
+                    <ul className="space-y-2 text-sm text-[#4A4A4A]">
                       <li>• {doctors[0].education}</li>
                       {doctors[0].certifications.map((cert, index) => (
                         <li key={index}>• {cert}</li>
@@ -343,8 +343,8 @@ const DoctorsPage = () => {
                   </div>
                   
                   <div>
-                    <h4 className="font-bold text-gray-900 mb-3">Contact Information</h4>
-                    <div className="space-y-2 text-sm text-gray-600">
+                    <h4 className="font-bold text-[#000000] mb-3">Contact Information</h4>
+                    <div className="space-y-2 text-sm text-[#4A4A4A]">
                       <div className="flex items-center space-x-2">
                         <Phone size={16} className="text-blue-600" />
                         <span>{doctors[0].phone}</span>
@@ -361,7 +361,7 @@ const DoctorsPage = () => {
                   </div>
                 </div>
                 
-                <button className="bg-gradient-to-r from-blue-600 to-blue-700 text-white px-8 py-4 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
+                <button className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-8 py-4 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
                   Schedule with Dr. {doctors[0].name.split(' ')[1]}
                 </button>
               </div>
@@ -371,7 +371,7 @@ const DoctorsPage = () => {
       </section>
 
       {/* Call to Action */}
-      <section className="py-20 bg-gradient-to-br from-blue-600 to-blue-700 text-white">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white">
         <div className="container mx-auto px-4 text-center">
           <h2 className="text-4xl font-bold mb-6">Ready to Meet Your Doctor?</h2>
           <p className="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
@@ -379,10 +379,10 @@ const DoctorsPage = () => {
           </p>
           
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <button className="bg-gradient-to-r from-orange-500 to-red-500 text-white px-8 py-4 rounded-full hover:from-orange-600 hover:to-red-600 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
+            <button className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-8 py-4 rounded-full hover:opacity-90 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
               Book Appointment Online
             </button>
-            <button className="bg-white/20 backdrop-blur-sm text-white px-8 py-4 rounded-full hover:bg-white/30 transition-all duration-300 font-semibold border border-white/30">
+            <button className="bg-[#FAFAFA]/20 backdrop-blur-sm text-white px-8 py-4 rounded-full hover:bg-[#FAFAFA]/30 transition-all duration-300 font-semibold border border-white/30">
               Call +1 (555) 123-4567
             </button>
           </div>

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -137,9 +137,9 @@ const FAQ = () => {
   return (
     <div className="pt-32">
       {/* Hero Section */}
-      <section className="py-20 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white relative overflow-hidden">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white relative overflow-hidden">
         <div className="absolute inset-0 opacity-10">
-          <div className="absolute top-20 left-20 w-64 h-64 bg-white rounded-full blur-3xl"></div>
+          <div className="absolute top-20 left-20 w-64 h-64 bg-[#FAFAFA] rounded-full blur-3xl"></div>
           <div className="absolute bottom-20 right-20 w-64 h-64 bg-orange-500 rounded-full blur-3xl"></div>
         </div>
         
@@ -147,7 +147,7 @@ const FAQ = () => {
           <div className="text-center mb-16">
             <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
               Frequently Asked
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-400 to-red-400 block">
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#FA6F42] to-[#F8753D] block">
                 Questions
               </span>
             </h1>
@@ -159,7 +159,7 @@ const FAQ = () => {
       </section>
 
       {/* Search and Filter */}
-      <section className="py-12 bg-white border-b">
+      <section className="py-12 bg-[#FAFAFA] border-b">
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto">
             <div className="relative mb-8">
@@ -181,7 +181,7 @@ const FAQ = () => {
                   className={`flex items-center space-x-2 px-4 py-2 rounded-full text-sm font-medium transition-all duration-300 ${
                     selectedCategory === category.id
                       ? 'bg-blue-600 text-white shadow-lg transform scale-105'
-                      : 'bg-gray-100 text-gray-600 hover:bg-blue-50 hover:text-blue-600'
+                      : 'bg-gray-100 text-[#4A4A4A] hover:bg-blue-50 hover:text-blue-600'
                   }`}
                 >
                   <category.icon size={16} />
@@ -200,12 +200,12 @@ const FAQ = () => {
             {filteredFAQs.length > 0 ? (
               <div className="space-y-4">
                 {filteredFAQs.map((faq, index) => (
-                  <div key={index} className="bg-white rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden">
+                  <div key={index} className="bg-[#FAFAFA] rounded-2xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden">
                     <button
                       onClick={() => toggleItem(index)}
                       className="w-full px-8 py-6 text-left flex items-center justify-between hover:bg-gray-50 transition-colors"
                     >
-                      <h3 className="text-lg font-bold text-gray-900 pr-4">{faq.question}</h3>
+                      <h3 className="text-lg font-bold text-[#000000] pr-4">{faq.question}</h3>
                       <ChevronDown 
                         className={`text-blue-600 transition-transform duration-300 ${
                           openItems.has(index) ? 'rotate-180' : ''
@@ -217,7 +217,7 @@ const FAQ = () => {
                     {openItems.has(index) && (
                       <div className="px-8 pb-6">
                         <div className="border-t border-gray-200 pt-6">
-                          <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+                          <p className="text-[#4A4A4A] leading-relaxed">{faq.answer}</p>
                         </div>
                       </div>
                     )}
@@ -229,8 +229,8 @@ const FAQ = () => {
                 <div className="text-gray-400 mb-4">
                   <Search size={64} className="mx-auto" />
                 </div>
-                <h3 className="text-2xl font-bold text-gray-900 mb-2">No questions found</h3>
-                <p className="text-gray-600 mb-6">Try adjusting your search terms or category filter.</p>
+                <h3 className="text-2xl font-bold text-[#000000] mb-2">No questions found</h3>
+                <p className="text-[#4A4A4A] mb-6">Try adjusting your search terms or category filter.</p>
                 <button 
                   onClick={() => {
                     setSearchTerm('');
@@ -247,22 +247,22 @@ const FAQ = () => {
       </section>
 
       {/* Quick Actions */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Still Have Questions?</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Still Have Questions?</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Our team is here to help. Contact us through any of these convenient methods for personalized assistance.
             </p>
           </div>
 
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
-            <div className="bg-gradient-to-br from-blue-50 to-white rounded-3xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 text-center group hover:-translate-y-2">
+            <div className="bg-[#F4F9F7] rounded-3xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 text-center group hover:-translate-y-2">
               <div className="w-20 h-20 bg-gradient-to-br from-blue-500 to-blue-600 rounded-3xl flex items-center justify-center mx-auto mb-6 group-hover:scale-110 transition-transform duration-300">
                 <Phone className="text-white" size={36} />
               </div>
-              <h3 className="text-2xl font-bold text-gray-900 mb-4">Call Us</h3>
-              <p className="text-gray-600 mb-6">Speak directly with our patient services team</p>
+              <h3 className="text-2xl font-bold text-[#000000] mb-4">Call Us</h3>
+              <p className="text-[#4A4A4A] mb-6">Speak directly with our patient services team</p>
               <div className="text-blue-600 font-bold text-lg mb-2">+1 (555) 123-4567</div>
               <div className="text-gray-500 text-sm">Mon-Fri: 8AM-6PM</div>
             </div>
@@ -271,8 +271,8 @@ const FAQ = () => {
               <div className="w-20 h-20 bg-gradient-to-br from-green-500 to-green-600 rounded-3xl flex items-center justify-center mx-auto mb-6 group-hover:scale-110 transition-transform duration-300">
                 <Mail className="text-white" size={36} />
               </div>
-              <h3 className="text-2xl font-bold text-gray-900 mb-4">Email Us</h3>
-              <p className="text-gray-600 mb-6">Send us your questions via email</p>
+              <h3 className="text-2xl font-bold text-[#000000] mb-4">Email Us</h3>
+              <p className="text-[#4A4A4A] mb-6">Send us your questions via email</p>
               <div className="text-green-600 font-bold text-lg mb-2">info@bigmedix.com</div>
               <div className="text-gray-500 text-sm">24-48 hour response</div>
             </div>
@@ -281,8 +281,8 @@ const FAQ = () => {
               <div className="w-20 h-20 bg-gradient-to-br from-purple-500 to-purple-600 rounded-3xl flex items-center justify-center mx-auto mb-6 group-hover:scale-110 transition-transform duration-300">
                 <Users className="text-white" size={36} />
               </div>
-              <h3 className="text-2xl font-bold text-gray-900 mb-4">Patient Portal</h3>
-              <p className="text-gray-600 mb-6">Message your care team securely online</p>
+              <h3 className="text-2xl font-bold text-[#000000] mb-4">Patient Portal</h3>
+              <p className="text-[#4A4A4A] mb-6">Message your care team securely online</p>
               <button className="bg-purple-600 text-white px-6 py-3 rounded-full hover:bg-purple-700 transition-colors font-semibold">
                 Login Portal
               </button>
@@ -292,8 +292,8 @@ const FAQ = () => {
               <div className="w-20 h-20 bg-gradient-to-br from-orange-500 to-orange-600 rounded-3xl flex items-center justify-center mx-auto mb-6 group-hover:scale-110 transition-transform duration-300">
                 <Calendar className="text-white" size={36} />
               </div>
-              <h3 className="text-2xl font-bold text-gray-900 mb-4">Schedule Visit</h3>
-              <p className="text-gray-600 mb-6">Book an appointment to discuss in person</p>
+              <h3 className="text-2xl font-bold text-[#000000] mb-4">Schedule Visit</h3>
+              <p className="text-[#4A4A4A] mb-6">Book an appointment to discuss in person</p>
               <button className="bg-orange-600 text-white px-6 py-3 rounded-full hover:bg-orange-700 transition-colors font-semibold">
                 Book Now
               </button>
@@ -306,8 +306,8 @@ const FAQ = () => {
       <section className="py-20 bg-gray-50">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Popular Help Topics</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Popular Help Topics</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Quick links to our most frequently requested information and resources.
             </p>
           </div>
@@ -351,14 +351,14 @@ const FAQ = () => {
                 color: 'from-indigo-500 to-indigo-600'
               }
             ].map((topic, index) => (
-              <div key={index} className="bg-white rounded-2xl p-6 shadow-lg hover:shadow-xl transition-all duration-300 cursor-pointer group hover:-translate-y-1">
+              <div key={index} className="bg-[#FAFAFA] rounded-2xl p-6 shadow-lg hover:shadow-xl transition-all duration-300 cursor-pointer group hover:-translate-y-1">
                 <div className={`w-12 h-12 bg-gradient-to-br ${topic.color} rounded-2xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300`}>
                   <topic.icon className="text-white" size={24} />
                 </div>
-                <h3 className="text-lg font-bold text-gray-900 mb-3 group-hover:text-blue-600 transition-colors">
+                <h3 className="text-lg font-bold text-[#000000] mb-3 group-hover:text-blue-600 transition-colors">
                   {topic.title}
                 </h3>
-                <p className="text-gray-600 text-sm leading-relaxed">
+                <p className="text-[#4A4A4A] text-sm leading-relaxed">
                   {topic.description}
                 </p>
               </div>

--- a/src/pages/Insurance.tsx
+++ b/src/pages/Insurance.tsx
@@ -91,9 +91,9 @@ const Insurance = () => {
   return (
     <div className="pt-32">
       {/* Hero Section */}
-      <section className="py-20 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white relative overflow-hidden">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white relative overflow-hidden">
         <div className="absolute inset-0 opacity-10">
-          <div className="absolute top-20 left-20 w-64 h-64 bg-white rounded-full blur-3xl"></div>
+          <div className="absolute top-20 left-20 w-64 h-64 bg-[#FAFAFA] rounded-full blur-3xl"></div>
           <div className="absolute bottom-20 right-20 w-64 h-64 bg-orange-500 rounded-full blur-3xl"></div>
         </div>
         
@@ -101,7 +101,7 @@ const Insurance = () => {
           <div className="text-center mb-16">
             <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
               Insurance &
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-400 to-red-400 block">
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#FA6F42] to-[#F8753D] block">
                 Payment
               </span>
             </h1>
@@ -113,22 +113,22 @@ const Insurance = () => {
       </section>
 
       {/* Insurance Verification */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Insurance Verification</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Insurance Verification</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Before your visit, we'll verify your insurance coverage to help you understand your benefits and any potential out-of-pocket costs.
             </p>
           </div>
 
           <div className="grid md:grid-cols-3 gap-8">
-            <div className="bg-gradient-to-br from-blue-50 to-white rounded-3xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 text-center">
+            <div className="bg-[#F4F9F7] rounded-3xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 text-center">
               <div className="w-20 h-20 bg-gradient-to-br from-blue-500 to-blue-600 rounded-3xl flex items-center justify-center mx-auto mb-6">
                 <Phone className="text-white" size={36} />
               </div>
-              <h3 className="text-2xl font-bold text-gray-900 mb-4">Call Us</h3>
-              <p className="text-gray-600 mb-6">Call our insurance verification team at +1 (555) 123-4567 to check your coverage before your appointment.</p>
+              <h3 className="text-2xl font-bold text-[#000000] mb-4">Call Us</h3>
+              <p className="text-[#4A4A4A] mb-6">Call our insurance verification team at +1 (555) 123-4567 to check your coverage before your appointment.</p>
               <button className="bg-blue-600 text-white px-6 py-3 rounded-full hover:bg-blue-700 transition-colors font-semibold">
                 Call Now
               </button>
@@ -138,8 +138,8 @@ const Insurance = () => {
               <div className="w-20 h-20 bg-gradient-to-br from-green-500 to-green-600 rounded-3xl flex items-center justify-center mx-auto mb-6">
                 <FileText className="text-white" size={36} />
               </div>
-              <h3 className="text-2xl font-bold text-gray-900 mb-4">Online Form</h3>
-              <p className="text-gray-600 mb-6">Submit your insurance information online and we'll verify your coverage and contact you with details.</p>
+              <h3 className="text-2xl font-bold text-[#000000] mb-4">Online Form</h3>
+              <p className="text-[#4A4A4A] mb-6">Submit your insurance information online and we'll verify your coverage and contact you with details.</p>
               <button className="bg-green-600 text-white px-6 py-3 rounded-full hover:bg-green-700 transition-colors font-semibold">
                 Submit Form
               </button>
@@ -149,8 +149,8 @@ const Insurance = () => {
               <div className="w-20 h-20 bg-gradient-to-br from-purple-500 to-purple-600 rounded-3xl flex items-center justify-center mx-auto mb-6">
                 <Shield className="text-white" size={36} />
               </div>
-              <h3 className="text-2xl font-bold text-gray-900 mb-4">Bring Your Card</h3>
-              <p className="text-gray-600 mb-6">Bring your insurance card to your appointment and we'll verify your coverage on the spot.</p>
+              <h3 className="text-2xl font-bold text-[#000000] mb-4">Bring Your Card</h3>
+              <p className="text-[#4A4A4A] mb-6">Bring your insurance card to your appointment and we'll verify your coverage on the spot.</p>
               <button className="bg-purple-600 text-white px-6 py-3 rounded-full hover:bg-purple-700 transition-colors font-semibold">
                 Learn More
               </button>
@@ -163,16 +163,16 @@ const Insurance = () => {
       <section className="py-20 bg-gray-50">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Accepted Insurance Plans</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Accepted Insurance Plans</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               We work with most major insurance providers to ensure you can access the care you need. If you don't see your plan listed, please contact us.
             </p>
           </div>
 
           <div className="space-y-8">
             {insurancePlans.map((category, categoryIndex) => (
-              <div key={categoryIndex} className="bg-white rounded-3xl shadow-lg overflow-hidden">
-                <div className="bg-gradient-to-r from-blue-600 to-blue-700 p-6">
+              <div key={categoryIndex} className="bg-[#FAFAFA] rounded-3xl shadow-lg overflow-hidden">
+                <div className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] p-6">
                   <h3 className="text-2xl font-bold text-white">{category.category}</h3>
                 </div>
                 
@@ -188,8 +188,8 @@ const Insurance = () => {
                           )}
                         </div>
                         <div className="flex-1">
-                          <div className="font-bold text-gray-900 mb-1">{plan.name}</div>
-                          <div className="text-sm text-gray-600">{plan.notes}</div>
+                          <div className="font-bold text-[#000000] mb-1">{plan.name}</div>
+                          <div className="text-sm text-[#4A4A4A]">{plan.notes}</div>
                         </div>
                       </div>
                     ))}
@@ -201,8 +201,8 @@ const Insurance = () => {
 
           <div className="text-center mt-12">
             <div className="bg-blue-50 rounded-2xl p-8 max-w-2xl mx-auto">
-              <h3 className="text-xl font-bold text-gray-900 mb-4">Don't See Your Plan?</h3>
-              <p className="text-gray-600 mb-6">
+              <h3 className="text-xl font-bold text-[#000000] mb-4">Don't See Your Plan?</h3>
+              <p className="text-[#4A4A4A] mb-6">
                 Insurance plans change frequently. If you don't see your specific plan listed, please contact our insurance verification team to confirm coverage.
               </p>
               <button className="bg-blue-600 text-white px-8 py-3 rounded-full hover:bg-blue-700 transition-colors font-semibold">
@@ -214,31 +214,31 @@ const Insurance = () => {
       </section>
 
       {/* Payment Options */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Payment Options</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Payment Options</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               We offer multiple convenient payment options and financial assistance programs to help make healthcare affordable for everyone.
             </p>
           </div>
 
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
             {paymentOptions.map((option, index) => (
-              <div key={index} className="bg-white rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden group hover:-translate-y-2">
+              <div key={index} className="bg-[#FAFAFA] rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden group hover:-translate-y-2">
                 <div className={`bg-gradient-to-br ${option.color} p-6`}>
-                  <div className="w-16 h-16 bg-white/20 rounded-2xl flex items-center justify-center mb-4">
+                  <div className="w-16 h-16 bg-[#FAFAFA]/20 rounded-2xl flex items-center justify-center mb-4">
                     <option.icon className="text-white" size={32} />
                   </div>
                   <h3 className="text-xl font-bold text-white">{option.title}</h3>
                 </div>
                 
                 <div className="p-6">
-                  <p className="text-gray-600 mb-6">{option.description}</p>
+                  <p className="text-[#4A4A4A] mb-6">{option.description}</p>
                   
                   <ul className="space-y-2">
                     {option.features.map((feature, featureIndex) => (
-                      <li key={featureIndex} className="flex items-center text-sm text-gray-600">
+                      <li key={featureIndex} className="flex items-center text-sm text-[#4A4A4A]">
                         <CheckCircle className="text-green-600 mr-2" size={16} />
                         {feature}
                       </li>
@@ -255,8 +255,8 @@ const Insurance = () => {
       <section className="py-20 bg-gray-50">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">How Billing Works</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">How Billing Works</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Our streamlined billing process is designed to be transparent and hassle-free, so you can focus on your health.
             </p>
           </div>
@@ -264,12 +264,12 @@ const Insurance = () => {
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
             {billingProcess.map((step, index) => (
               <div key={index} className="relative">
-                <div className="bg-white rounded-3xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 text-center group hover:-translate-y-2">
+                <div className="bg-[#FAFAFA] rounded-3xl p-8 shadow-lg hover:shadow-xl transition-all duration-300 text-center group hover:-translate-y-2">
                   <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-600 rounded-full flex items-center justify-center mx-auto mb-6 text-white text-2xl font-bold group-hover:scale-110 transition-transform">
                     {step.step}
                   </div>
-                  <h3 className="text-xl font-bold text-gray-900 mb-4">{step.title}</h3>
-                  <p className="text-gray-600 leading-relaxed">{step.description}</p>
+                  <h3 className="text-xl font-bold text-[#000000] mb-4">{step.title}</h3>
+                  <p className="text-[#4A4A4A] leading-relaxed">{step.description}</p>
                 </div>
                 
                 {index < billingProcess.length - 1 && (
@@ -284,7 +284,7 @@ const Insurance = () => {
       </section>
 
       {/* Financial Assistance */}
-      <section className="py-20 bg-gradient-to-br from-blue-600 to-blue-700 text-white">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
             <h2 className="text-4xl font-bold mb-6">Financial Assistance Programs</h2>
@@ -294,8 +294,8 @@ const Insurance = () => {
           </div>
 
           <div className="grid md:grid-cols-3 gap-8">
-            <div className="bg-white/10 backdrop-blur-sm rounded-3xl p-8 text-center">
-              <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-6">
+            <div className="bg-[#FAFAFA]/10 backdrop-blur-sm rounded-3xl p-8 text-center">
+              <div className="w-16 h-16 bg-[#FAFAFA]/20 rounded-full flex items-center justify-center mx-auto mb-6">
                 <Shield className="text-white" size={32} />
               </div>
               <h3 className="text-2xl font-bold mb-4">Charity Care</h3>
@@ -308,8 +308,8 @@ const Insurance = () => {
               </ul>
             </div>
 
-            <div className="bg-white/10 backdrop-blur-sm rounded-3xl p-8 text-center">
-              <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-6">
+            <div className="bg-[#FAFAFA]/10 backdrop-blur-sm rounded-3xl p-8 text-center">
+              <div className="w-16 h-16 bg-[#FAFAFA]/20 rounded-full flex items-center justify-center mx-auto mb-6">
                 <DollarSign className="text-white" size={32} />
               </div>
               <h3 className="text-2xl font-bold mb-4">Payment Plans</h3>
@@ -322,8 +322,8 @@ const Insurance = () => {
               </ul>
             </div>
 
-            <div className="bg-white/10 backdrop-blur-sm rounded-3xl p-8 text-center">
-              <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-6">
+            <div className="bg-[#FAFAFA]/10 backdrop-blur-sm rounded-3xl p-8 text-center">
+              <div className="w-16 h-16 bg-[#FAFAFA]/20 rounded-full flex items-center justify-center mx-auto mb-6">
                 <FileText className="text-white" size={32} />
               </div>
               <h3 className="text-2xl font-bold mb-4">Medicaid Assistance</h3>
@@ -338,7 +338,7 @@ const Insurance = () => {
           </div>
 
           <div className="text-center mt-12">
-            <button className="bg-white text-blue-600 px-8 py-4 rounded-full hover:bg-blue-50 transition-colors font-bold shadow-xl hover:shadow-2xl transform hover:scale-105">
+            <button className="bg-[#FAFAFA] text-blue-600 px-8 py-4 rounded-full hover:bg-blue-50 transition-colors font-bold shadow-xl hover:shadow-2xl transform hover:scale-105">
               Apply for Financial Assistance
             </button>
           </div>
@@ -346,11 +346,11 @@ const Insurance = () => {
       </section>
 
       {/* Contact Information */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Questions About Billing or Insurance?</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Questions About Billing or Insurance?</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Our patient financial services team is here to help you understand your insurance benefits and payment options.
             </p>
           </div>
@@ -358,29 +358,29 @@ const Insurance = () => {
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
             <div className="bg-gray-50 rounded-2xl p-6 text-center hover:bg-blue-50 transition-colors">
               <Phone className="text-blue-600 mx-auto mb-4" size={32} />
-              <h3 className="font-bold text-gray-900 mb-2">Phone</h3>
-              <p className="text-gray-600">+1 (555) 123-4567</p>
+              <h3 className="font-bold text-[#000000] mb-2">Phone</h3>
+              <p className="text-[#4A4A4A]">+1 (555) 123-4567</p>
               <p className="text-sm text-gray-500">Mon-Fri: 8AM-5PM</p>
             </div>
 
             <div className="bg-gray-50 rounded-2xl p-6 text-center hover:bg-blue-50 transition-colors">
               <FileText className="text-green-600 mx-auto mb-4" size={32} />
-              <h3 className="font-bold text-gray-900 mb-2">Email</h3>
-              <p className="text-gray-600">billing@bigmedix.com</p>
+              <h3 className="font-bold text-[#000000] mb-2">Email</h3>
+              <p className="text-[#4A4A4A]">billing@bigmedix.com</p>
               <p className="text-sm text-gray-500">24-48 hour response</p>
             </div>
 
             <div className="bg-gray-50 rounded-2xl p-6 text-center hover:bg-blue-50 transition-colors">
               <CreditCard className="text-purple-600 mx-auto mb-4" size={32} />
-              <h3 className="font-bold text-gray-900 mb-2">Online Portal</h3>
-              <p className="text-gray-600">Pay bills online</p>
+              <h3 className="font-bold text-[#000000] mb-2">Online Portal</h3>
+              <p className="text-[#4A4A4A]">Pay bills online</p>
               <p className="text-sm text-gray-500">Available 24/7</p>
             </div>
 
             <div className="bg-gray-50 rounded-2xl p-6 text-center hover:bg-blue-50 transition-colors">
               <Shield className="text-orange-600 mx-auto mb-4" size={32} />
-              <h3 className="font-bold text-gray-900 mb-2">In Person</h3>
-              <p className="text-gray-600">Visit any location</p>
+              <h3 className="font-bold text-[#000000] mb-2">In Person</h3>
+              <p className="text-[#4A4A4A]">Visit any location</p>
               <p className="text-sm text-gray-500">Business hours</p>
             </div>
           </div>

--- a/src/pages/PatientResources.tsx
+++ b/src/pages/PatientResources.tsx
@@ -102,9 +102,9 @@ const PatientResources = () => {
   return (
     <div className="pt-32">
       {/* Hero Section */}
-      <section className="py-20 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white relative overflow-hidden">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white relative overflow-hidden">
         <div className="absolute inset-0 opacity-10">
-          <div className="absolute top-20 left-20 w-64 h-64 bg-white rounded-full blur-3xl"></div>
+          <div className="absolute top-20 left-20 w-64 h-64 bg-[#FAFAFA] rounded-full blur-3xl"></div>
           <div className="absolute bottom-20 right-20 w-64 h-64 bg-orange-500 rounded-full blur-3xl"></div>
         </div>
         
@@ -112,7 +112,7 @@ const PatientResources = () => {
           <div className="text-center mb-16">
             <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
               Patient
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-400 to-red-400 block">
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#FA6F42] to-[#F8753D] block">
                 Resources
               </span>
             </h1>
@@ -124,11 +124,11 @@ const PatientResources = () => {
       </section>
 
       {/* Quick Links */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Quick Access</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Quick Access</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Access the most commonly used patient services and tools with just one click.
             </p>
           </div>
@@ -138,15 +138,15 @@ const PatientResources = () => {
               <a
                 key={index}
                 href={link.link}
-                className="group bg-white rounded-3xl p-8 shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-100 hover:-translate-y-4"
+                className="group bg-[#FAFAFA] rounded-3xl p-8 shadow-lg hover:shadow-2xl transition-all duration-300 border border-gray-100 hover:-translate-y-4"
               >
                 <div className={`w-20 h-20 bg-gradient-to-br ${link.color} rounded-3xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform duration-300`}>
                   <link.icon className="text-white" size={36} />
                 </div>
-                <h3 className="text-2xl font-bold text-gray-900 mb-4 group-hover:text-blue-600 transition-colors">
+                <h3 className="text-2xl font-bold text-[#000000] mb-4 group-hover:text-blue-600 transition-colors">
                   {link.title}
                 </h3>
-                <p className="text-gray-600 leading-relaxed">
+                <p className="text-[#4A4A4A] leading-relaxed">
                   {link.description}
                 </p>
               </a>
@@ -159,18 +159,18 @@ const PatientResources = () => {
       <section className="py-20 bg-gray-50">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Downloadable Resources</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Downloadable Resources</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Download important forms, educational materials, and preparation guides to help you prepare for your visit.
             </p>
           </div>
 
           <div className="space-y-12">
             {resources.map((category, categoryIndex) => (
-              <div key={categoryIndex} className="bg-white rounded-3xl shadow-lg overflow-hidden">
+              <div key={categoryIndex} className="bg-[#FAFAFA] rounded-3xl shadow-lg overflow-hidden">
                 <div className={`bg-gradient-to-r ${category.color} p-8`}>
                   <div className="flex items-center space-x-4">
-                    <div className="w-16 h-16 bg-white/20 rounded-2xl flex items-center justify-center">
+                    <div className="w-16 h-16 bg-[#FAFAFA]/20 rounded-2xl flex items-center justify-center">
                       <category.icon className="text-white" size={32} />
                     </div>
                     <div>
@@ -186,7 +186,7 @@ const PatientResources = () => {
                       <div key={itemIndex} className="group bg-gray-50 rounded-2xl p-6 hover:bg-blue-50 transition-all duration-300 cursor-pointer hover:-translate-y-1">
                         <div className="flex items-start justify-between mb-4">
                           <div className="flex-1">
-                            <h4 className="font-bold text-gray-900 mb-2 group-hover:text-blue-600 transition-colors">
+                            <h4 className="font-bold text-[#000000] mb-2 group-hover:text-blue-600 transition-colors">
                               {item.name}
                             </h4>
                             <div className="flex items-center space-x-4 text-sm text-gray-500">
@@ -211,50 +211,50 @@ const PatientResources = () => {
       </section>
 
       {/* Contact Information */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Contact Information</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Contact Information</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               Get in touch with the right department for your needs. Our staff is here to help you navigate your healthcare journey.
             </p>
           </div>
 
           <div className="grid md:grid-cols-3 gap-8">
             {contactInfo.map((location, index) => (
-              <div key={index} className="bg-white rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 border border-gray-100 p-8 hover:-translate-y-2">
+              <div key={index} className="bg-[#FAFAFA] rounded-3xl shadow-lg hover:shadow-xl transition-all duration-300 border border-gray-100 p-8 hover:-translate-y-2">
                 <div className="text-center mb-6">
                   <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-blue-600 rounded-2xl flex items-center justify-center mx-auto mb-4">
                     <MapPin className="text-white" size={28} />
                   </div>
-                  <h3 className="text-2xl font-bold text-gray-900 mb-2">{location.title}</h3>
+                  <h3 className="text-2xl font-bold text-[#000000] mb-2">{location.title}</h3>
                 </div>
 
                 <div className="space-y-4">
                   <div className="flex items-center space-x-3">
                     <Phone className="text-green-600" size={20} />
                     <div>
-                      <div className="font-bold text-gray-900">{location.phone}</div>
+                      <div className="font-bold text-[#000000]">{location.phone}</div>
                     </div>
                   </div>
                   
                   <div className="flex items-center space-x-3">
                     <Clock className="text-blue-600" size={20} />
                     <div>
-                      <div className="text-gray-600">{location.hours}</div>
+                      <div className="text-[#4A4A4A]">{location.hours}</div>
                     </div>
                   </div>
                   
                   <div className="flex items-start space-x-3">
                     <MapPin className="text-orange-600 mt-1" size={20} />
                     <div>
-                      <div className="text-gray-600">{location.address}</div>
+                      <div className="text-[#4A4A4A]">{location.address}</div>
                     </div>
                   </div>
                 </div>
 
                 <div className="mt-6 pt-6 border-t border-gray-200">
-                  <div className="text-sm font-medium text-gray-900 mb-3">Services Available:</div>
+                  <div className="text-sm font-medium text-[#000000] mb-3">Services Available:</div>
                   <div className="flex flex-wrap gap-2">
                     {location.services.map((service, serviceIndex) => (
                       <span key={serviceIndex} className="bg-blue-50 text-blue-600 px-3 py-1 rounded-full text-xs font-medium">
@@ -270,10 +270,10 @@ const PatientResources = () => {
       </section>
 
       {/* Privacy & Security */}
-      <section className="py-20 bg-gradient-to-br from-blue-600 to-blue-700 text-white">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <div className="w-20 h-20 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-6">
+            <div className="w-20 h-20 bg-[#FAFAFA]/20 rounded-full flex items-center justify-center mx-auto mb-6">
               <Shield className="text-white" size={36} />
             </div>
             <h2 className="text-4xl font-bold mb-6">Your Privacy & Security</h2>
@@ -298,7 +298,7 @@ const PatientResources = () => {
               }
             ].map((item, index) => (
               <div key={index} className="text-center">
-                <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-4">
+                <div className="w-16 h-16 bg-[#FAFAFA]/20 rounded-full flex items-center justify-center mx-auto mb-4">
                   <Shield className="text-white" size={28} />
                 </div>
                 <h3 className="text-xl font-bold mb-3">{item.title}</h3>
@@ -308,7 +308,7 @@ const PatientResources = () => {
           </div>
 
           <div className="text-center mt-12">
-            <button className="bg-white text-blue-600 px-8 py-4 rounded-full hover:bg-blue-50 transition-all duration-300 font-bold shadow-xl hover:shadow-2xl transform hover:scale-105">
+            <button className="bg-[#FAFAFA] text-blue-600 px-8 py-4 rounded-full hover:bg-blue-50 transition-all duration-300 font-bold shadow-xl hover:shadow-2xl transform hover:scale-105">
               View Privacy Policy
             </button>
           </div>

--- a/src/pages/ServicesPage.tsx
+++ b/src/pages/ServicesPage.tsx
@@ -117,9 +117,9 @@ const ServicesPage = () => {
   return (
     <div className="pt-32">
       {/* Hero Section */}
-      <section className="py-20 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white relative overflow-hidden">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white relative overflow-hidden">
         <div className="absolute inset-0 opacity-10">
-          <div className="absolute top-20 left-20 w-64 h-64 bg-white rounded-full blur-3xl"></div>
+          <div className="absolute top-20 left-20 w-64 h-64 bg-[#FAFAFA] rounded-full blur-3xl"></div>
           <div className="absolute bottom-20 right-20 w-64 h-64 bg-orange-500 rounded-full blur-3xl"></div>
         </div>
         
@@ -127,7 +127,7 @@ const ServicesPage = () => {
           <div className="text-center mb-16">
             <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
               Medical
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-400 to-red-400 block">
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#FA6F42] to-[#F8753D] block">
                 Services
               </span>
             </h1>
@@ -139,11 +139,11 @@ const ServicesPage = () => {
       </section>
 
       {/* Services Overview */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Our Specialties</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Our Specialties</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               We provide world-class medical services across multiple specialties, ensuring you receive the best possible care for all your health needs.
             </p>
           </div>
@@ -154,7 +154,7 @@ const ServicesPage = () => {
                 key={index}
                 data-index={index}
                 data-animate="service"
-                className={`group bg-white rounded-3xl p-8 shadow-lg hover:shadow-2xl transition-all duration-500 border border-gray-100 cursor-pointer transform hover:-translate-y-4 ${
+                className={`group bg-[#FAFAFA] rounded-3xl p-8 shadow-lg hover:shadow-2xl transition-all duration-500 border border-gray-100 cursor-pointer transform hover:-translate-y-4 ${
                   visibleItems.has(index.toString()) 
                     ? 'translate-y-0 opacity-100' 
                     : 'translate-y-8 opacity-0'
@@ -165,11 +165,11 @@ const ServicesPage = () => {
                   <service.icon className="text-white" size={36} />
                 </div>
                 
-                <h3 className="text-2xl font-bold text-gray-900 mb-4 group-hover:text-blue-600 transition-colors">
+                <h3 className="text-2xl font-bold text-[#000000] mb-4 group-hover:text-blue-600 transition-colors">
                   {service.title}
                 </h3>
                 
-                <p className="text-gray-600 mb-6 leading-relaxed">
+                <p className="text-[#4A4A4A] mb-6 leading-relaxed">
                   {service.description}
                 </p>
 
@@ -186,7 +186,7 @@ const ServicesPage = () => {
                   </div>
                 </div>
 
-                <button className="w-full bg-gradient-to-r from-blue-600 to-blue-700 text-white py-3 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105">
+                <button className="w-full bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white py-3 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105">
                   Learn More
                 </button>
               </div>
@@ -207,24 +207,24 @@ const ServicesPage = () => {
                       <service.icon className="text-white" size={28} />
                     </div>
                     <div>
-                      <h3 className="text-3xl font-bold text-gray-900">{service.title}</h3>
+                      <h3 className="text-3xl font-bold text-[#000000]">{service.title}</h3>
                       <div className="text-blue-600 font-medium">Comprehensive Care</div>
                     </div>
                   </div>
                   
-                  <p className="text-xl text-gray-600 leading-relaxed">
+                  <p className="text-xl text-[#4A4A4A] leading-relaxed">
                     {service.description}
                   </p>
 
                   <div className="grid md:grid-cols-2 gap-8">
                     <div>
-                      <h4 className="text-lg font-bold text-gray-900 mb-4 flex items-center">
+                      <h4 className="text-lg font-bold text-[#000000] mb-4 flex items-center">
                         <CheckCircle className="text-green-600 mr-2" size={20} />
                         Services Offered
                       </h4>
                       <ul className="space-y-2">
                         {service.features.map((feature, featureIndex) => (
-                          <li key={featureIndex} className="flex items-center text-gray-600">
+                          <li key={featureIndex} className="flex items-center text-[#4A4A4A]">
                             <div className={`w-2 h-2 bg-gradient-to-r ${service.color} rounded-full mr-3`}></div>
                             {feature}
                           </li>
@@ -233,13 +233,13 @@ const ServicesPage = () => {
                     </div>
                     
                     <div>
-                      <h4 className="text-lg font-bold text-gray-900 mb-4 flex items-center">
+                      <h4 className="text-lg font-bold text-[#000000] mb-4 flex items-center">
                         <Activity className="text-blue-600 mr-2" size={20} />
                         Procedures
                       </h4>
                       <ul className="space-y-2">
                         {service.procedures.map((procedure, procedureIndex) => (
-                          <li key={procedureIndex} className="flex items-center text-gray-600">
+                          <li key={procedureIndex} className="flex items-center text-[#4A4A4A]">
                             <div className={`w-2 h-2 bg-gradient-to-r ${service.color} rounded-full mr-3`}></div>
                             {procedure}
                           </li>
@@ -249,7 +249,7 @@ const ServicesPage = () => {
                   </div>
 
                   <div className="flex flex-col sm:flex-row gap-4">
-                    <button className="bg-gradient-to-r from-blue-600 to-blue-700 text-white px-8 py-4 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
+                    <button className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-8 py-4 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
                       Schedule Consultation
                     </button>
                     <button className="flex items-center justify-center space-x-2 text-blue-600 hover:text-orange-500 transition-colors font-semibold px-8 py-4 border-2 border-blue-600 rounded-full hover:border-orange-500">
@@ -270,14 +270,14 @@ const ServicesPage = () => {
                   </div>
                   
                   {/* Stats Card */}
-                  <div className="absolute -bottom-8 -right-8 bg-white rounded-2xl p-6 shadow-xl">
+                  <div className="absolute -bottom-8 -right-8 bg-[#FAFAFA] rounded-2xl p-6 shadow-xl">
                     <div className="flex items-center space-x-4">
                       <div className={`w-12 h-12 bg-gradient-to-br ${service.color} rounded-full flex items-center justify-center`}>
                         <Award className="text-white" size={20} />
                       </div>
                       <div>
                         <div className="font-bold text-gray-800">{service.specialists} Specialists</div>
-                        <div className="text-sm text-gray-600">Expert Care Team</div>
+                        <div className="text-sm text-[#4A4A4A]">Expert Care Team</div>
                       </div>
                     </div>
                   </div>
@@ -292,7 +292,7 @@ const ServicesPage = () => {
       <section className="py-20 bg-gradient-to-br from-red-600 to-red-700 text-white">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <div className="w-20 h-20 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-6">
+            <div className="w-20 h-20 bg-[#FAFAFA]/20 rounded-full flex items-center justify-center mx-auto mb-6">
               <Activity className="text-white" size={36} />
             </div>
             <h2 className="text-4xl font-bold mb-6">24/7 Emergency Care</h2>
@@ -320,7 +320,7 @@ const ServicesPage = () => {
               }
             ].map((feature, index) => (
               <div key={index} className="text-center">
-                <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-4">
+                <div className="w-16 h-16 bg-[#FAFAFA]/20 rounded-full flex items-center justify-center mx-auto mb-4">
                   <feature.icon className="text-white" size={28} />
                 </div>
                 <h3 className="text-xl font-bold mb-3">{feature.title}</h3>
@@ -332,7 +332,7 @@ const ServicesPage = () => {
           <div className="text-center mt-12">
             <div className="text-3xl font-bold mb-2">Emergency Hotline</div>
             <div className="text-2xl text-red-200 mb-6">+1 (555) 911-HELP</div>
-            <button className="bg-white text-red-600 px-8 py-4 rounded-full hover:bg-red-50 transition-all duration-300 font-bold shadow-xl hover:shadow-2xl transform hover:scale-105">
+            <button className="bg-[#FAFAFA] text-red-600 px-8 py-4 rounded-full hover:bg-red-50 transition-all duration-300 font-bold shadow-xl hover:shadow-2xl transform hover:scale-105">
               Emergency Services Info
             </button>
           </div>
@@ -340,11 +340,11 @@ const ServicesPage = () => {
       </section>
 
       {/* Insurance & Payment */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Insurance & Payment Options</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-[#000000] mb-6">Insurance & Payment Options</h2>
+            <p className="text-xl text-[#4A4A4A] max-w-3xl mx-auto">
               We accept most major insurance plans and offer flexible payment options to make quality healthcare accessible to everyone.
             </p>
           </div>
@@ -362,13 +362,13 @@ const ServicesPage = () => {
             ].map((insurance, index) => (
               <div key={index} className="bg-gray-50 rounded-2xl p-6 text-center hover:bg-blue-50 transition-colors duration-300 group">
                 <Shield className="text-blue-600 mx-auto mb-4 group-hover:text-blue-700 transition-colors" size={32} />
-                <div className="font-medium text-gray-900 group-hover:text-blue-700 transition-colors">{insurance}</div>
+                <div className="font-medium text-[#000000] group-hover:text-blue-700 transition-colors">{insurance}</div>
               </div>
             ))}
           </div>
 
           <div className="text-center mt-12">
-            <button className="bg-gradient-to-r from-blue-600 to-blue-700 text-white px-8 py-4 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
+            <button className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-8 py-4 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
               Verify Insurance Coverage
             </button>
           </div>

--- a/src/pages/TestimonialsPage.tsx
+++ b/src/pages/TestimonialsPage.tsx
@@ -161,9 +161,9 @@ const TestimonialsPage = () => {
   return (
     <div className="pt-32">
       {/* Hero Section */}
-      <section className="py-20 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white relative overflow-hidden">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white relative overflow-hidden">
         <div className="absolute inset-0 opacity-10">
-          <div className="absolute top-20 left-20 w-64 h-64 bg-white rounded-full blur-3xl animate-pulse"></div>
+          <div className="absolute top-20 left-20 w-64 h-64 bg-[#FAFAFA] rounded-full blur-3xl animate-pulse"></div>
           <div className="absolute bottom-20 right-20 w-64 h-64 bg-orange-500 rounded-full blur-3xl animate-pulse"></div>
           <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-96 h-96 bg-purple-500 rounded-full blur-3xl animate-pulse"></div>
         </div>
@@ -172,7 +172,7 @@ const TestimonialsPage = () => {
           <div className="text-center mb-16">
             <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
               Patient
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-400 to-red-400 block">
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#FA6F42] to-[#F8753D] block">
                 Stories
               </span>
             </h1>
@@ -184,7 +184,7 @@ const TestimonialsPage = () => {
       </section>
 
       {/* Stats Section */}
-      <section className="py-16 bg-white">
+      <section className="py-16 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
           <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
             {stats.map((stat, index) => (
@@ -192,10 +192,10 @@ const TestimonialsPage = () => {
                 <div className="w-20 h-20 bg-gradient-to-br from-blue-50 to-blue-100 rounded-3xl flex items-center justify-center mx-auto mb-4 group-hover:scale-110 transition-all duration-300 shadow-lg">
                   <stat.icon className={stat.color} size={36} />
                 </div>
-                <div className="text-4xl font-bold text-gray-900 mb-2 group-hover:text-blue-600 transition-colors">
+                <div className="text-4xl font-bold text-[#000000] mb-2 group-hover:text-blue-600 transition-colors">
                   {stat.number}
                 </div>
-                <div className="text-gray-600 group-hover:text-gray-800 transition-colors">
+                <div className="text-[#4A4A4A] group-hover:text-gray-800 transition-colors">
                   {stat.label}
                 </div>
               </div>
@@ -208,8 +208,8 @@ const TestimonialsPage = () => {
       <section className="py-12 bg-gray-50 border-b">
         <div className="container mx-auto px-4">
           <div className="text-center mb-8">
-            <h2 className="text-3xl font-bold text-gray-900 mb-4">Filter by Specialty</h2>
-            <p className="text-gray-600">See what patients are saying about specific departments and treatments.</p>
+            <h2 className="text-3xl font-bold text-[#000000] mb-4">Filter by Specialty</h2>
+            <p className="text-[#4A4A4A]">See what patients are saying about specific departments and treatments.</p>
           </div>
           
           <div className="flex flex-wrap justify-center gap-3">
@@ -220,7 +220,7 @@ const TestimonialsPage = () => {
                 className={`px-4 py-2 rounded-full text-sm font-medium transition-all duration-300 ${
                   selectedCategory === category
                     ? 'bg-blue-600 text-white shadow-lg transform scale-105'
-                    : 'bg-white text-gray-600 hover:bg-blue-50 hover:text-blue-600 shadow-sm'
+                    : 'bg-[#FAFAFA] text-[#4A4A4A] hover:bg-blue-50 hover:text-blue-600 shadow-sm'
                 }`}
               >
                 {category === 'all' ? 'All Departments' : category}
@@ -239,7 +239,7 @@ const TestimonialsPage = () => {
                 key={testimonial.id}
                 data-index={index}
                 data-animate="testimonial"
-                className={`group bg-white rounded-3xl p-8 shadow-lg hover:shadow-2xl transition-all duration-500 cursor-pointer transform hover:-translate-y-4 ${
+                className={`group bg-[#FAFAFA] rounded-3xl p-8 shadow-lg hover:shadow-2xl transition-all duration-500 cursor-pointer transform hover:-translate-y-4 ${
                   visibleItems.has(index.toString()) 
                     ? 'translate-y-0 opacity-100' 
                     : 'translate-y-8 opacity-0'
@@ -269,13 +269,13 @@ const TestimonialsPage = () => {
                       )}
                     </div>
                     <div>
-                      <div className="font-bold text-gray-900 group-hover:text-blue-600 transition-colors">
+                      <div className="font-bold text-[#000000] group-hover:text-blue-600 transition-colors">
                         {testimonial.name}
                       </div>
-                      <div className="text-sm text-gray-600 group-hover:text-gray-700 transition-colors">
+                      <div className="text-sm text-[#4A4A4A] group-hover:text-gray-700 transition-colors">
                         {testimonial.condition}
                       </div>
-                      <div className="text-xs text-gray-500 group-hover:text-gray-600 transition-colors">
+                      <div className="text-xs text-gray-500 group-hover:text-[#4A4A4A] transition-colors">
                         {new Date(testimonial.date).toLocaleDateString()}
                       </div>
                     </div>
@@ -296,7 +296,7 @@ const TestimonialsPage = () => {
                   <span className="bg-gradient-to-r from-blue-500 to-blue-600 text-white px-3 py-1 rounded-full text-xs font-medium">
                     {testimonial.treatment}
                   </span>
-                  <div className="flex items-center space-x-2 text-gray-500 group-hover:text-gray-600 transition-colors">
+                  <div className="flex items-center space-x-2 text-gray-500 group-hover:text-[#4A4A4A] transition-colors">
                     <ThumbsUp size={16} />
                     <span className="text-sm">{testimonial.helpful} helpful</span>
                   </div>
@@ -310,22 +310,22 @@ const TestimonialsPage = () => {
               <div className="text-gray-400 mb-4">
                 <Quote size={64} className="mx-auto" />
               </div>
-              <h3 className="text-2xl font-bold text-gray-900 mb-2">No testimonials found</h3>
-              <p className="text-gray-600">Try selecting a different specialty filter.</p>
+              <h3 className="text-2xl font-bold text-[#000000] mb-2">No testimonials found</h3>
+              <p className="text-[#4A4A4A]">Try selecting a different specialty filter.</p>
             </div>
           )}
         </div>
       </section>
 
       {/* Featured Success Story */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-[#FAFAFA]">
         <div className="container mx-auto px-4">
-          <div className="bg-gradient-to-br from-blue-50 to-white rounded-3xl p-8 lg:p-12 shadow-xl">
+          <div className="bg-[#F4F9F7] rounded-3xl p-8 lg:p-12 shadow-xl">
             <div className="text-center mb-12">
-              <div className="inline-block bg-gradient-to-r from-orange-500 to-red-500 text-white px-6 py-3 rounded-full text-sm font-semibold mb-6">
+              <div className="inline-block bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-6 py-3 rounded-full text-sm font-semibold mb-6">
                 Featured Success Story
               </div>
-              <h2 className="text-4xl font-bold text-gray-900 mb-6">A Life-Changing Experience</h2>
+              <h2 className="text-4xl font-bold text-[#000000] mb-6">A Life-Changing Experience</h2>
             </div>
             
             <div className="grid lg:grid-cols-2 gap-12 items-center">
@@ -335,14 +335,14 @@ const TestimonialsPage = () => {
                   alt={testimonials[6].name}
                   className="w-full h-96 object-cover rounded-3xl shadow-xl"
                 />
-                <div className="absolute -bottom-6 -right-6 bg-white rounded-2xl p-6 shadow-xl">
+                <div className="absolute -bottom-6 -right-6 bg-[#FAFAFA] rounded-2xl p-6 shadow-xl">
                   <div className="flex items-center space-x-4">
                     <div className="w-12 h-12 bg-gradient-to-br from-green-500 to-green-600 rounded-full flex items-center justify-center">
                       <Heart className="text-white" size={20} />
                     </div>
                     <div>
                       <div className="font-bold text-gray-800">Cancer Survivor</div>
-                      <div className="text-sm text-gray-600">2 Years Cancer-Free</div>
+                      <div className="text-sm text-[#4A4A4A]">2 Years Cancer-Free</div>
                     </div>
                   </div>
                 </div>
@@ -366,14 +366,14 @@ const TestimonialsPage = () => {
                     className="w-16 h-16 rounded-full object-cover border-2 border-blue-200"
                   />
                   <div>
-                    <div className="font-bold text-gray-900 text-lg">{testimonials[6].name}</div>
+                    <div className="font-bold text-[#000000] text-lg">{testimonials[6].name}</div>
                     <div className="text-blue-600 font-medium">{testimonials[6].condition}</div>
-                    <div className="text-sm text-gray-600">{testimonials[6].treatment}</div>
+                    <div className="text-sm text-[#4A4A4A]">{testimonials[6].treatment}</div>
                   </div>
                 </div>
                 
                 <div className="bg-blue-50 rounded-2xl p-6">
-                  <h4 className="font-bold text-gray-900 mb-3">Treatment Highlights:</h4>
+                  <h4 className="font-bold text-[#000000] mb-3">Treatment Highlights:</h4>
                   <ul className="space-y-2 text-gray-700">
                     <li>• Comprehensive cancer care team</li>
                     <li>• Personalized treatment plan</li>
@@ -388,7 +388,7 @@ const TestimonialsPage = () => {
       </section>
 
       {/* Call to Action */}
-      <section className="py-20 bg-gradient-to-br from-blue-600 to-blue-700 text-white">
+      <section className="py-20 bg-gradient-to-br from-[#0F4537] to-[#2E6656] text-white">
         <div className="container mx-auto px-4 text-center">
           <h2 className="text-4xl font-bold mb-6">Share Your Experience</h2>
           <p className="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
@@ -396,10 +396,10 @@ const TestimonialsPage = () => {
           </p>
           
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <button className="bg-gradient-to-r from-orange-500 to-red-500 text-white px-8 py-4 rounded-full hover:from-orange-600 hover:to-red-600 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
+            <button className="bg-gradient-to-r from-[#FA6F42] to-[#F8753D] text-white px-8 py-4 rounded-full hover:opacity-90 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
               Write a Review
             </button>
-            <button className="bg-white/20 backdrop-blur-sm text-white px-8 py-4 rounded-full hover:bg-white/30 transition-all duration-300 font-semibold border border-white/30">
+            <button className="bg-[#FAFAFA]/20 backdrop-blur-sm text-white px-8 py-4 rounded-full hover:bg-[#FAFAFA]/30 transition-all duration-300 font-semibold border border-white/30">
               Schedule Your Visit
             </button>
           </div>


### PR DESCRIPTION
## Summary
- update hero gradient and CTA sections to dark teal
- apply accent orange gradients for buttons
- switch headings to black and paragraphs to dark gray
- use pastel background for sections and soft gray cards

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68512409dfb08324a1379c309f53c76d