### PR TITLE
Refactor theme colors

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,11 +5,11 @@ import { Facebook, Twitter, Instagram, Linkedin, Phone, Mail, MapPin, Clock, Hea
 
 const Footer = () => {
   return (
-    <footer className="bg-gradient-to-br from-gray-900 via-blue-900 to-gray-900 text-white relative overflow-hidden">
+    <footer className="bg-card-bg text-text-paragraph relative overflow-hidden">
       {/* Background Pattern */}
       <div className="absolute inset-0 opacity-5">
-        <div className="absolute top-20 left-20 w-64 h-64 bg-blue-500 rounded-full blur-3xl"></div>
-        <div className="absolute bottom-20 right-20 w-64 h-64 bg-orange-500 rounded-full blur-3xl"></div>
+        <div className="absolute top-20 left-20 w-64 h-64 bg-primary-from rounded-full blur-3xl"></div>
+        <div className="absolute bottom-20 right-20 w-64 h-64 bg-accent rounded-full blur-3xl"></div>
       </div>
 
       <div className="container mx-auto px-4 py-16 relative z-10">
@@ -18,15 +18,15 @@ const Footer = () => {
           {/* Company Info */}
           <div className="space-y-6">
             <Link to="/" className="flex items-center space-x-3 group cursor-pointer">
-              <div className="w-12 h-12 bg-gradient-to-br from-blue-500 to-blue-600 rounded-full flex items-center justify-center shadow-lg group-hover:shadow-xl transition-all duration-300 group-hover:scale-110">
+              <div className="w-12 h-12 bg-gradient-to-br from-primary-from to-primary-to rounded-full flex items-center justify-center shadow-lg group-hover:shadow-xl transition-all duration-300 group-hover:scale-110">
                 <span className="text-white font-bold text-2xl">+</span>
               </div>
               <div>
-                <span className="text-3xl font-bold">BigMedix</span>
-                <div className="text-sm text-blue-200">Medical Center</div>
+                <span className="text-3xl font-bold text-heading">BigMedix</span>
+                <div className="text-sm text-accent">Medical Center</div>
               </div>
             </Link>
-            <p className="text-gray-300 leading-relaxed">
+            <p className="text-text-paragraph/70 leading-relaxed">
               Providing compassionate, comprehensive healthcare services to our community for over 25 years. Your health is our priority, and your trust is our foundation.
             </p>
             <div className="flex space-x-4">
@@ -49,7 +49,7 @@ const Footer = () => {
 
           {/* Quick Links */}
           <div>
-            <h3 className="text-2xl font-bold mb-6 text-white">Quick Links</h3>
+            <h3 className="text-2xl font-bold mb-6 text-heading">Quick Links</h3>
             <ul className="space-y-3">
               {[
                 { name: 'Home', href: '/' },
@@ -62,7 +62,7 @@ const Footer = () => {
                 <li key={index}>
                   <Link 
                     to={link.href} 
-                    className="text-gray-300 hover:text-white hover:translate-x-2 transition-all duration-300 inline-block"
+                    className="text-text-paragraph/70 hover:text-text-paragraph hover:translate-x-2 transition-all duration-300 inline-block"
                   >
                     {link.name}
                   </Link>
@@ -73,7 +73,7 @@ const Footer = () => {
 
           {/* Patient Resources */}
           <div>
-            <h3 className="text-2xl font-bold mb-6 text-white">Patient Resources</h3>
+            <h3 className="text-2xl font-bold mb-6 text-heading">Patient Resources</h3>
             <ul className="space-y-3">
               {[
                 { name: 'Patient Portal', href: '/patient-resources' },
@@ -86,7 +86,7 @@ const Footer = () => {
                 <li key={index}>
                   <Link 
                     to={link.href} 
-                    className="text-gray-300 hover:text-white hover:translate-x-2 transition-all duration-300 inline-block"
+                    className="text-text-paragraph/70 hover:text-text-paragraph hover:translate-x-2 transition-all duration-300 inline-block"
                   >
                     {link.name}
                   </Link>
@@ -97,35 +97,35 @@ const Footer = () => {
 
           {/* Contact Info */}
           <div>
-            <h3 className="text-2xl font-bold mb-6 text-white">Contact Info</h3>
+            <h3 className="text-2xl font-bold mb-6 text-heading">Contact Info</h3>
             <div className="space-y-4">
               <div className="flex items-start space-x-3 group">
-                <MapPin className="text-blue-400 mt-1 group-hover:text-blue-300 transition-colors" size={20} />
+                <MapPin className="text-accent mt-1 group-hover:text-accent-hover transition-colors" size={20} />
                 <div>
-                  <div className="font-bold text-white">Main Location</div>
-                  <div className="text-gray-300">123 Medical Plaza<br />Health City, HC 12345</div>
+                  <div className="font-bold text-heading">Main Location</div>
+                  <div className="text-text-paragraph/70">123 Medical Plaza<br />Health City, HC 12345</div>
                 </div>
               </div>
               <div className="flex items-start space-x-3 group">
                 <Phone className="text-green-400 mt-1 group-hover:text-green-300 transition-colors" size={20} />
                 <div>
-                  <div className="font-bold text-white">Phone</div>
-                  <div className="text-gray-300">+1 (555) 123-4567</div>
+                  <div className="font-bold text-heading">Phone</div>
+                  <div className="text-text-paragraph/70">+1 (555) 123-4567</div>
                   <div className="text-sm text-red-300">Emergency: +1 (555) 911-HELP</div>
                 </div>
               </div>
               <div className="flex items-start space-x-3 group">
                 <Mail className="text-orange-400 mt-1 group-hover:text-orange-300 transition-colors" size={20} />
                 <div>
-                  <div className="font-bold text-white">Email</div>
-                  <div className="text-gray-300">info@bigmedix.com</div>
+                  <div className="font-bold text-heading">Email</div>
+                  <div className="text-text-paragraph/70">info@bigmedix.com</div>
                 </div>
               </div>
               <div className="flex items-start space-x-3 group">
                 <Clock className="text-purple-400 mt-1 group-hover:text-purple-300 transition-colors" size={20} />
                 <div>
-                  <div className="font-bold text-white">Emergency</div>
-                  <div className="text-gray-300">24/7 Available</div>
+                  <div className="font-bold text-heading">Emergency</div>
+                  <div className="text-text-paragraph/70">24/7 Available</div>
                 </div>
               </div>
             </div>
@@ -135,19 +135,19 @@ const Footer = () => {
         {/* Stats Section */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-8 py-12 border-t border-white/20 border-b border-white/20">
           {[
-            { icon: Award, number: '25+', label: 'Years Experience', color: 'text-yellow-400' },
-            { icon: Users, number: '50+', label: 'Expert Doctors', color: 'text-blue-400' },
-            { icon: Heart, number: '15K+', label: 'Happy Patients', color: 'text-red-400' },
-            { icon: Shield, number: '24/7', label: 'Emergency Care', color: 'text-green-400' }
+            { icon: Award, number: '25+', label: 'Years Experience', color: 'text-accent' },
+            { icon: Users, number: '50+', label: 'Expert Doctors', color: 'text-accent' },
+            { icon: Heart, number: '15K+', label: 'Happy Patients', color: 'text-accent' },
+            { icon: Shield, number: '24/7', label: 'Emergency Care', color: 'text-accent' }
           ].map((stat, index) => (
             <div key={index} className="text-center group cursor-pointer">
               <div className={`w-16 h-16 bg-white/10 backdrop-blur-sm rounded-2xl flex items-center justify-center mx-auto mb-4 group-hover:bg-white/20 transition-all duration-300 group-hover:scale-110`}>
                 <stat.icon className={stat.color} size={32} />
               </div>
-              <div className="text-3xl font-bold text-white mb-2 group-hover:text-blue-300 transition-colors">
+              <div className="text-3xl font-bold text-heading mb-2 group-hover:text-accent transition-colors">
                 {stat.number}
               </div>
-              <div className="text-gray-300 group-hover:text-white transition-colors">
+              <div className="text-text-paragraph/70 group-hover:text-text-paragraph transition-colors">
                 {stat.label}
               </div>
             </div>
@@ -157,10 +157,10 @@ const Footer = () => {
         {/* Bottom Bar */}
         <div className="pt-8">
           <div className="flex flex-col md:flex-row justify-between items-center">
-            <div className="text-gray-300 mb-4 md:mb-0">
+            <div className="text-text-paragraph/70 mb-4 md:mb-0">
               © 2024 BigMedix Medical Center. All rights reserved.
             </div>
-            <div className="flex space-x-8 text-gray-300">
+            <div className="flex space-x-8 text-text-paragraph/70">
               {[
                 'Privacy Policy',
                 'Terms of Service', 
@@ -170,7 +170,7 @@ const Footer = () => {
                 <a 
                   key={index}
                   href="#" 
-                  className="hover:text-white transition-colors duration-300 hover:underline"
+                  className="text-text-paragraph/70 hover:text-accent transition-colors duration-300 hover:underline"
                 >
                   {link}
                 </a>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -65,9 +65,9 @@ const Header = () => {
             <Link 
               to="/" 
               className={`font-semibold transition-all duration-300 hover:scale-105 ${
-                isActive('/') 
-                  ? (isScrolled ? 'text-blue-600' : 'text-orange-300') 
-                  : (isScrolled ? 'text-gray-700 hover:text-blue-600' : 'text-white hover:text-blue-200')
+                isActive('/')
+                  ? (isScrolled ? 'text-accent font-bold' : 'text-white font-bold')
+                  : (isScrolled ? 'text-text-paragraph hover:text-primary-from' : 'text-white hover:text-primary-from')
               }`}
             >
               Home
@@ -75,9 +75,9 @@ const Header = () => {
             <Link 
               to="/about" 
               className={`font-semibold transition-all duration-300 hover:scale-105 ${
-                isActive('/about') 
-                  ? (isScrolled ? 'text-blue-600' : 'text-orange-300') 
-                  : (isScrolled ? 'text-gray-700 hover:text-blue-600' : 'text-white hover:text-blue-200')
+                isActive('/about')
+                  ? (isScrolled ? 'text-accent font-bold' : 'text-white font-bold')
+                  : (isScrolled ? 'text-text-paragraph hover:text-primary-from' : 'text-white hover:text-primary-from')
               }`}
             >
               About Us
@@ -86,9 +86,9 @@ const Header = () => {
             <div className="relative group">
               <button 
                 className={`flex items-center space-x-1 font-semibold transition-all duration-300 hover:scale-105 ${
-                  isActive('/services') 
-                    ? (isScrolled ? 'text-blue-600' : 'text-orange-300') 
-                    : (isScrolled ? 'text-gray-700 hover:text-blue-600' : 'text-white hover:text-blue-200')
+                  isActive('/services')
+                    ? (isScrolled ? 'text-accent font-bold' : 'text-white font-bold')
+                    : (isScrolled ? 'text-text-paragraph hover:text-primary-from' : 'text-white hover:text-primary-from')
                 }`}
                 onMouseEnter={() => setIsServicesOpen(true)}
                 onMouseLeave={() => setIsServicesOpen(false)}
@@ -103,13 +103,13 @@ const Header = () => {
                   onMouseEnter={() => setIsServicesOpen(true)}
                   onMouseLeave={() => setIsServicesOpen(false)}
                 >
-                  <Link to="/services" className="block px-6 py-3 text-gray-700 hover:text-blue-600 hover:bg-blue-50 transition-colors">
+                  <Link to="/services" className="block px-6 py-3 text-text-paragraph hover:text-primary-from hover:bg-primary-from/5 transition-colors">
                     All Services
                   </Link>
-                  <Link to="/patient-resources" className="block px-6 py-3 text-gray-700 hover:text-blue-600 hover:bg-blue-50 transition-colors">
+                  <Link to="/patient-resources" className="block px-6 py-3 text-text-paragraph hover:text-primary-from hover:bg-primary-from/5 transition-colors">
                     Patient Resources
                   </Link>
-                  <Link to="/insurance" className="block px-6 py-3 text-gray-700 hover:text-blue-600 hover:bg-blue-50 transition-colors">
+                  <Link to="/insurance" className="block px-6 py-3 text-text-paragraph hover:text-primary-from hover:bg-primary-from/5 transition-colors">
                     Insurance & Payment
                   </Link>
                 </div>
@@ -119,9 +119,9 @@ const Header = () => {
             <Link 
               to="/doctors" 
               className={`font-semibold transition-all duration-300 hover:scale-105 ${
-                isActive('/doctors') 
-                  ? (isScrolled ? 'text-blue-600' : 'text-orange-300') 
-                  : (isScrolled ? 'text-gray-700 hover:text-blue-600' : 'text-white hover:text-blue-200')
+                isActive('/doctors')
+                  ? (isScrolled ? 'text-accent font-bold' : 'text-white font-bold')
+                  : (isScrolled ? 'text-text-paragraph hover:text-primary-from' : 'text-white hover:text-primary-from')
               }`}
             >
               Doctors
@@ -129,9 +129,9 @@ const Header = () => {
             <Link 
               to="/blog" 
               className={`font-semibold transition-all duration-300 hover:scale-105 ${
-                isActive('/blog') 
-                  ? (isScrolled ? 'text-blue-600' : 'text-orange-300') 
-                  : (isScrolled ? 'text-gray-700 hover:text-blue-600' : 'text-white hover:text-blue-200')
+                isActive('/blog')
+                  ? (isScrolled ? 'text-accent font-bold' : 'text-white font-bold')
+                  : (isScrolled ? 'text-text-paragraph hover:text-primary-from' : 'text-white hover:text-primary-from')
               }`}
             >
               Blog
@@ -139,9 +139,9 @@ const Header = () => {
             <Link 
               to="/contact" 
               className={`font-semibold transition-all duration-300 hover:scale-105 ${
-                isActive('/contact') 
-                  ? (isScrolled ? 'text-blue-600' : 'text-orange-300') 
-                  : (isScrolled ? 'text-gray-700 hover:text-blue-600' : 'text-white hover:text-blue-200')
+                isActive('/contact')
+                  ? (isScrolled ? 'text-accent font-bold' : 'text-white font-bold')
+                  : (isScrolled ? 'text-text-paragraph hover:text-primary-from' : 'text-white hover:text-primary-from')
               }`}
             >
               Contact
@@ -165,18 +165,18 @@ const Header = () => {
 
         {/* Mobile Navigation */}
         {isMenuOpen && (
-          <div className="lg:hidden mt-4 py-4 border-t border-gray-200 bg-white rounded-lg shadow-xl animate-fadeIn">
+          <div className="lg:hidden mt-4 py-4 border-t border-card-bg-alt bg-card-bg rounded-lg shadow-xl animate-fadeIn">
             <div className="flex flex-col space-y-4 px-4">
-              <Link to="/" className="text-gray-700 hover:text-blue-600 transition-colors font-medium py-2 hover:bg-blue-50 px-4 rounded-lg">Home</Link>
-              <Link to="/about" className="text-gray-700 hover:text-blue-600 transition-colors font-medium py-2 hover:bg-blue-50 px-4 rounded-lg">About Us</Link>
-              <Link to="/services" className="text-gray-700 hover:text-blue-600 transition-colors font-medium py-2 hover:bg-blue-50 px-4 rounded-lg">Services</Link>
-              <Link to="/doctors" className="text-gray-700 hover:text-blue-600 transition-colors font-medium py-2 hover:bg-blue-50 px-4 rounded-lg">Doctors</Link>
-              <Link to="/blog" className="text-gray-700 hover:text-blue-600 transition-colors font-medium py-2 hover:bg-blue-50 px-4 rounded-lg">Blog</Link>
-              <Link to="/patient-resources" className="text-gray-700 hover:text-blue-600 transition-colors font-medium py-2 hover:bg-blue-50 px-4 rounded-lg">Patient Resources</Link>
-              <Link to="/contact" className="text-gray-700 hover:text-blue-600 transition-colors font-medium py-2 hover:bg-blue-50 px-4 rounded-lg">Contact</Link>
-              <Link 
+              <Link to="/" className="text-text-paragraph hover:text-primary-from transition-colors font-medium py-2 hover:bg-primary-from/5 px-4 rounded-lg">Home</Link>
+              <Link to="/about" className="text-text-paragraph hover:text-primary-from transition-colors font-medium py-2 hover:bg-primary-from/5 px-4 rounded-lg">About Us</Link>
+              <Link to="/services" className="text-text-paragraph hover:text-primary-from transition-colors font-medium py-2 hover:bg-primary-from/5 px-4 rounded-lg">Services</Link>
+              <Link to="/doctors" className="text-text-paragraph hover:text-primary-from transition-colors font-medium py-2 hover:bg-primary-from/5 px-4 rounded-lg">Doctors</Link>
+              <Link to="/blog" className="text-text-paragraph hover:text-primary-from transition-colors font-medium py-2 hover:bg-primary-from/5 px-4 rounded-lg">Blog</Link>
+              <Link to="/patient-resources" className="text-text-paragraph hover:text-primary-from transition-colors font-medium py-2 hover:bg-primary-from/5 px-4 rounded-lg">Patient Resources</Link>
+              <Link to="/contact" className="text-text-paragraph hover:text-primary-from transition-colors font-medium py-2 hover:bg-primary-from/5 px-4 rounded-lg">Contact</Link>
+              <Link
                 to="/contact"
-                className="bg-gradient-to-r from-orange-500 to-red-500 text-white px-6 py-3 rounded-full hover:from-orange-600 hover:to-red-600 transition-all duration-300 font-medium w-fit transform hover:scale-105"
+                className="bg-gradient-to-r from-btn-primary to-btn-hover text-white px-6 py-3 rounded-full hover:from-btn-hover hover:to-btn-primary transition-all duration-300 font-medium w-fit transform hover:scale-105"
               >
                 Book Appointment
               </Link>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -10,12 +10,12 @@ const Hero = () => {
   }, []);
 
   return (
-    <section id="home" className="relative min-h-screen bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 overflow-hidden">
+    <section id="home" className="relative min-h-screen bg-gradient-to-br from-primary-from to-primary-to overflow-hidden">
       {/* Background Pattern */}
       <div className="absolute inset-0 opacity-10">
-        <div className="absolute top-20 left-20 w-32 h-32 bg-white rounded-full animate-float"></div>
-        <div className="absolute top-40 right-32 w-24 h-24 bg-blue-300 rounded-full animate-float-delayed"></div>
-        <div className="absolute bottom-32 left-1/4 w-40 h-40 bg-blue-200 rounded-full animate-float-slow"></div>
+        <div className="absolute top-20 left-20 w-32 h-32 bg-card-bg rounded-full animate-float"></div>
+        <div className="absolute top-40 right-32 w-24 h-24 bg-accent/50 rounded-full animate-float-delayed"></div>
+        <div className="absolute bottom-32 left-1/4 w-40 h-40 bg-accent/30 rounded-full animate-float-slow"></div>
       </div>
 
       <div className="container mx-auto px-4 pt-32 pb-20">
@@ -23,14 +23,14 @@ const Hero = () => {
           <div className={`space-y-8 transform transition-all duration-1000 ${isVisible ? 'translate-x-0 opacity-100' : '-translate-x-20 opacity-0'}`}>
             <div className="space-y-6">
               <div className="inline-block">
-                <span className="bg-gradient-to-r from-orange-500 to-red-500 text-white px-6 py-2 rounded-full text-sm font-semibold animate-pulse">
+                <span className="bg-gradient-to-r from-accent to-accent-hover text-white px-6 py-2 rounded-full text-sm font-semibold animate-pulse">
                   #1 Medical Center in the City
                 </span>
               </div>
               
               <h1 className="text-5xl lg:text-7xl font-bold text-white leading-tight">
                 Your Health is Our
-                <span className="text-transparent bg-clip-text bg-gradient-to-r from-orange-400 to-red-400 block animate-gradient">
+                <span className="text-transparent bg-clip-text bg-gradient-to-r from-accent to-accent-hover block animate-gradient">
                   Top Priority
                 </span>
               </h1>
@@ -41,12 +41,12 @@ const Hero = () => {
             </div>
 
             <div className="flex flex-col sm:flex-row gap-6">
-              <button className="group bg-gradient-to-r from-orange-500 to-red-500 text-white px-8 py-4 rounded-full hover:from-orange-600 hover:to-red-600 transition-all duration-300 font-semibold flex items-center justify-center space-x-3 shadow-2xl hover:shadow-orange-500/25 transform hover:scale-105 hover:-translate-y-1">
+              <button className="group bg-gradient-to-r from-accent to-accent-hover text-white px-8 py-4 rounded-full hover:from-accent-hover hover:to-accent transition-all duration-300 font-semibold flex items-center justify-center space-x-3 shadow-2xl hover:shadow-accent/25 transform hover:scale-105 hover:-translate-y-1">
                 <span>Book Appointment</span>
                 <ArrowRight size={20} className="group-hover:translate-x-1 transition-transform"  />
               </button>
               
-              <button className="group flex items-center space-x-3 text-white hover:text-orange-300 transition-all duration-300 font-semibold">
+              <button className="group flex items-center space-x-3 text-white hover:text-accent-hover transition-all duration-300 font-semibold">
                 <div className="w-12 h-12 bg-white/20 backdrop-blur-sm rounded-full flex items-center justify-center group-hover:bg-white/30 transition-all duration-300 group-hover:scale-110">
                   <Play size={20} className="ml-1"  />
                 </div>
@@ -57,33 +57,33 @@ const Hero = () => {
             <div className="grid grid-cols-2 md:grid-cols-4 gap-6 pt-8">
               <div className="text-center group cursor-pointer">
                 <div className="w-16 h-16 bg-white/10 backdrop-blur-sm rounded-2xl flex items-center justify-center mx-auto mb-4 group-hover:bg-white/20 transition-all duration-300 group-hover:scale-110">
-                  <Shield className="text-orange-400" size={32}  />
+                  <Shield className="text-accent" size={32}  />
                 </div>
-                <div className="text-3xl font-bold text-white group-hover:text-orange-300 transition-colors">24/7</div>
+                <div className="text-3xl font-bold text-white group-hover:text-accent-hover transition-colors">24/7</div>
                 <div className="text-blue-200 text-sm">Emergency Care</div>
               </div>
               
               <div className="text-center group cursor-pointer">
                 <div className="w-16 h-16 bg-white/10 backdrop-blur-sm rounded-2xl flex items-center justify-center mx-auto mb-4 group-hover:bg-white/20 transition-all duration-300 group-hover:scale-110">
-                  <Award className="text-orange-400" size={32}  />
+                  <Award className="text-accent" size={32}  />
                 </div>
-                <div className="text-3xl font-bold text-white group-hover:text-orange-300 transition-colors">25+</div>
+                <div className="text-3xl font-bold text-white group-hover:text-accent-hover transition-colors">25+</div>
                 <div className="text-blue-200 text-sm">Years Experience</div>
               </div>
               
               <div className="text-center group cursor-pointer">
                 <div className="w-16 h-16 bg-white/10 backdrop-blur-sm rounded-2xl flex items-center justify-center mx-auto mb-4 group-hover:bg-white/20 transition-all duration-300 group-hover:scale-110">
-                  <Users className="text-orange-400" size={32}  />
+                  <Users className="text-accent" size={32}  />
                 </div>
-                <div className="text-3xl font-bold text-white group-hover:text-orange-300 transition-colors">50+</div>
+                <div className="text-3xl font-bold text-white group-hover:text-accent-hover transition-colors">50+</div>
                 <div className="text-blue-200 text-sm">Expert Doctors</div>
               </div>
               
               <div className="text-center group cursor-pointer">
                 <div className="w-16 h-16 bg-white/10 backdrop-blur-sm rounded-2xl flex items-center justify-center mx-auto mb-4 group-hover:bg-white/20 transition-all duration-300 group-hover:scale-110">
-                  <Clock className="text-orange-400" size={32}  />
+                  <Clock className="text-accent" size={32}  />
                 </div>
-                <div className="text-3xl font-bold text-white group-hover:text-orange-300 transition-colors">15K+</div>
+                <div className="text-3xl font-bold text-white group-hover:text-accent-hover transition-colors">15K+</div>
                 <div className="text-blue-200 text-sm">Happy Patients</div>
               </div>
             </div>
@@ -101,34 +101,34 @@ const Hero = () => {
               </div>
               
               {/* Floating Cards */}
-              <div className="absolute -top-8 -left-8 bg-white rounded-2xl p-6 shadow-2xl animate-float">
+              <div className="absolute -top-8 -left-8 bg-card-bg rounded-2xl p-6 shadow-2xl animate-float">
                 <div className="flex items-center space-x-4">
                   <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
                     <div className="w-6 h-6 bg-green-500 rounded-full animate-pulse"></div>
                   </div>
                   <div>
-                    <div className="font-bold text-gray-800">24/7 Available</div>
-                    <div className="text-sm text-gray-600">Emergency Services</div>
+                    <div className="font-bold text-heading">24/7 Available</div>
+                    <div className="text-sm text-body">Emergency Services</div>
                   </div>
                 </div>
               </div>
               
-              <div className="absolute -bottom-8 -right-8 bg-white rounded-2xl p-6 shadow-2xl animate-float-delayed">
+              <div className="absolute -bottom-8 -right-8 bg-card-bg rounded-2xl p-6 shadow-2xl animate-float-delayed">
                 <div className="flex items-center space-x-4">
-                  <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
-                    <Award className="text-blue-600" size={24}  />
+                  <div className="w-12 h-12 bg-accent/20 rounded-full flex items-center justify-center">
+                    <Award className="text-accent" size={24}  />
                   </div>
                   <div>
-                    <div className="font-bold text-gray-800">Award Winning</div>
-                    <div className="text-sm text-gray-600">Healthcare Excellence</div>
+                    <div className="font-bold text-heading">Award Winning</div>
+                    <div className="text-sm text-body">Healthcare Excellence</div>
                   </div>
                 </div>
               </div>
             </div>
             
             {/* Background Decorations */}
-            <div className="absolute -top-4 -right-4 w-full h-full bg-gradient-to-br from-orange-400 to-red-500 rounded-3xl -z-10 opacity-20"></div>
-            <div className="absolute -bottom-8 -left-8 w-32 h-32 bg-gradient-to-br from-blue-400 to-blue-600 rounded-full -z-20 animate-pulse"></div>
+            <div className="absolute -top-4 -right-4 w-full h-full bg-gradient-to-br from-accent to-accent-hover rounded-3xl -z-10 opacity-20"></div>
+            <div className="absolute -bottom-8 -left-8 w-32 h-32 bg-gradient-to-br from-accent to-accent-hover rounded-full -z-20 animate-pulse"></div>
           </div>
         </div>
       </div>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -84,27 +84,27 @@ const Services = () => {
   ];
 
   return (
-    <section id="services" className="py-20 bg-gradient-to-br from-gray-50 to-blue-50 relative overflow-hidden">
+    <section id="services" className="py-20 bg-content-bg relative overflow-hidden">
       {/* Background Pattern */}
       <div className="absolute inset-0 opacity-5">
-        <div className="absolute top-20 left-20 w-64 h-64 bg-blue-500 rounded-full blur-3xl"></div>
-        <div className="absolute bottom-20 right-20 w-64 h-64 bg-orange-500 rounded-full blur-3xl"></div>
+        <div className="absolute top-20 left-20 w-64 h-64 bg-primary-from rounded-full blur-3xl"></div>
+        <div className="absolute bottom-20 right-20 w-64 h-64 bg-accent rounded-full blur-3xl"></div>
       </div>
 
       <div className="container mx-auto px-4 relative z-10">
         <div className="text-center mb-16">
           <div className="inline-block mb-6">
-            <span className="bg-gradient-to-r from-blue-600 to-blue-700 text-white px-6 py-3 rounded-full text-sm font-semibold shadow-lg">
+            <span className="bg-gradient-to-r from-primary-from to-primary-to text-white px-6 py-3 rounded-full text-sm font-semibold shadow-lg">
               Our Medical Services
             </span>
           </div>
-          <h2 className="text-4xl md:text-6xl font-bold text-gray-900 mb-6 leading-tight">
+          <h2 className="text-4xl md:text-6xl font-bold text-heading mb-6 leading-tight">
             Comprehensive Healthcare
-            <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-orange-500 block">
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-primary-from to-accent block">
               Solutions
             </span>
           </h2>
-          <p className="text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed">
+          <p className="text-xl text-body max-w-3xl mx-auto leading-relaxed">
             We provide world-class medical services across multiple specialties, ensuring you receive the best possible care for all your health needs.
           </p>
         </div>
@@ -115,7 +115,7 @@ const Services = () => {
               key={index}
               data-index={index}
               data-animate="service"
-              className={`group bg-white rounded-3xl p-8 shadow-lg hover:shadow-2xl transition-all duration-500 border border-gray-100 cursor-pointer transform hover:-translate-y-4 ${
+              className={`group bg-card-bg rounded-3xl p-8 shadow-lg hover:shadow-2xl transition-all duration-500 border border-card-alt cursor-pointer transform hover:-translate-y-4 ${
                 visibleItems.has(index.toString()) 
                   ? 'translate-y-0 opacity-100' 
                   : 'translate-y-8 opacity-0'
@@ -126,24 +126,24 @@ const Services = () => {
                 <service.icon className="text-white" size={36} />
               </div>
               
-              <h3 className="text-2xl font-bold text-gray-900 mb-4 group-hover:text-blue-600 transition-colors">
+              <h3 className="text-2xl font-bold text-heading mb-4 group-hover:text-primary-to transition-colors">
                 {service.title}
               </h3>
               
-              <p className="text-gray-600 mb-6 leading-relaxed">
+              <p className="text-body mb-6 leading-relaxed">
                 {service.description}
               </p>
               
               <ul className="space-y-3 mb-6">
                 {service.features.map((feature, featureIndex) => (
-                  <li key={featureIndex} className="flex items-center text-sm text-gray-500 group-hover:text-gray-700 transition-colors">
+                  <li key={featureIndex} className="flex items-center text-sm text-body group-hover:text-heading transition-colors">
                     <div className={`w-2 h-2 bg-gradient-to-r ${service.color} rounded-full mr-3 group-hover:scale-125 transition-transform`}></div>
                     {feature}
                   </li>
                 ))}
               </ul>
 
-              <button className="flex items-center space-x-2 text-blue-600 font-semibold group-hover:text-orange-500 transition-colors">
+              <button className="flex items-center space-x-2 text-primary-from font-semibold group-hover:text-accent-hover transition-colors">
                 <span>Learn More</span>
                 <ArrowRight size={16} className="group-hover:translate-x-1 transition-transform" />
               </button>
@@ -152,7 +152,7 @@ const Services = () => {
         </div>
 
         <div className="text-center mt-16">
-          <button className="bg-gradient-to-r from-blue-600 to-blue-700 text-white px-10 py-4 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105 hover:-translate-y-1">
+          <button className="bg-gradient-to-r from-primary-from to-primary-to text-white px-10 py-4 rounded-full hover:from-primary-to hover:to-primary-from transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105 hover:-translate-y-1">
             View All Services
           </button>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -70,14 +70,14 @@ html {
 }
 
 ::-webkit-scrollbar-track {
-  background: #f1f5f9;
+  background: #F1F1F1; /* card-alt */
 }
 
 ::-webkit-scrollbar-thumb {
-  background: linear-gradient(to bottom, #3b82f6, #1d4ed8);
+  background: linear-gradient(to bottom, #0F4537, #2E6656);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: linear-gradient(to bottom, #1d4ed8, #1e40af);
+  background: linear-gradient(to bottom, #2E6656, #0F4537);
 }

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -80,10 +80,10 @@ const ContactPage = () => {
   return (
     <div className="pt-32">
       {/* Hero Section */}
-      <section className="py-20 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white relative overflow-hidden">
+      <section className="py-20 bg-gradient-to-br from-primary-from to-primary-to text-white relative overflow-hidden">
         <div className="absolute inset-0 opacity-10">
-          <div className="absolute top-20 left-20 w-64 h-64 bg-white rounded-full blur-3xl"></div>
-          <div className="absolute bottom-20 right-20 w-64 h-64 bg-orange-500 rounded-full blur-3xl"></div>
+          <div className="absolute top-20 left-20 w-64 h-64 bg-card-bg rounded-full blur-3xl"></div>
+          <div className="absolute bottom-20 right-20 w-64 h-64 bg-accent rounded-full blur-3xl"></div>
         </div>
         
         <div className="container mx-auto px-4 relative z-10">
@@ -102,10 +102,10 @@ const ContactPage = () => {
       </section>
 
       {/* Quick Contact Cards */}
-      <section className="py-16 bg-white">
+      <section className="py-16 bg-card-bg">
         <div className="container mx-auto px-4">
           <div className="grid md:grid-cols-3 gap-8 mb-16">
-            <div className="bg-gradient-to-br from-red-500 to-red-600 rounded-3xl p-8 text-white shadow-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-2">
+            <div className="bg-gradient-to-br from-btn-primary to-btn-hover rounded-3xl p-8 text-white shadow-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-2">
               <div className="w-16 h-16 bg-white/20 rounded-2xl flex items-center justify-center mb-6">
                 <Phone className="text-white" size={32} />
               </div>
@@ -115,7 +115,7 @@ const ContactPage = () => {
               <div className="text-red-200">Available 24/7</div>
             </div>
 
-            <div className="bg-gradient-to-br from-blue-500 to-blue-600 rounded-3xl p-8 text-white shadow-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-2">
+            <div className="bg-gradient-to-br from-primary-from to-primary-to rounded-3xl p-8 text-white shadow-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-2">
               <div className="w-16 h-16 bg-white/20 rounded-2xl flex items-center justify-center mb-6">
                 <Calendar className="text-white" size={32} />
               </div>
@@ -125,13 +125,13 @@ const ContactPage = () => {
               <div className="text-blue-200">Mon-Fri: 8AM-6PM</div>
             </div>
 
-            <div className="bg-gradient-to-br from-green-500 to-green-600 rounded-3xl p-8 text-white shadow-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-2">
+            <div className="bg-gradient-to-br from-primary-from to-primary-to rounded-3xl p-8 text-white shadow-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-2">
               <div className="w-16 h-16 bg-white/20 rounded-2xl flex items-center justify-center mb-6">
                 <MessageCircle className="text-white" size={32} />
               </div>
               <h3 className="text-2xl font-bold mb-4">Patient Portal</h3>
               <p className="text-green-100 mb-6">Access records and message your doctor</p>
-              <button className="bg-white text-green-600 px-6 py-3 rounded-full font-bold hover:bg-green-50 transition-colors">
+              <button className="bg-btn-primary text-white px-6 py-3 rounded-full font-bold hover:bg-btn-hover transition-colors">
                 Login Portal
               </button>
             </div>
@@ -140,38 +140,38 @@ const ContactPage = () => {
       </section>
 
       {/* Main Contact Form */}
-      <section className="py-20 bg-gray-50">
+      <section className="py-20 bg-content-bg">
         <div className="container mx-auto px-4">
           <div className="grid lg:grid-cols-2 gap-16">
             {/* Contact Form */}
-            <div className="bg-white rounded-3xl p-8 shadow-xl">
+            <div className="bg-card-bg rounded-3xl p-8 shadow-xl">
               <div className="flex items-center mb-8">
-                <Send className="text-blue-600 mr-4" size={32} />
-                <h2 className="text-3xl font-bold text-gray-900">Send us a Message</h2>
+                <Send className="text-primary-from mr-4" size={32} />
+                <h2 className="text-3xl font-bold text-heading">Send us a Message</h2>
               </div>
               
               <form className="space-y-6">
                 <div className="grid sm:grid-cols-2 gap-6">
                   <div className="group">
-                    <label className="block text-sm font-bold text-gray-700 mb-3">First Name *</label>
+                    <label className="block text-sm font-bold text-heading mb-3">First Name *</label>
                     <input
                       type="text"
                       name="firstName"
                       value={formData.firstName}
                       onChange={handleInputChange}
-                      className="w-full px-6 py-4 rounded-2xl border-2 border-gray-200 focus:border-blue-500 focus:ring-4 focus:ring-blue-100 outline-none transition-all duration-300 group-hover:border-gray-300"
+                      className="w-full px-6 py-4 rounded-2xl border-2 border-card-bg-alt focus:border-primary-from focus:ring-4 focus:ring-primary-from/20 outline-none transition-all duration-300 group-hover:border-card-bg-alt"
                       placeholder="Enter your first name"
                       required
                     />
                   </div>
                   <div className="group">
-                    <label className="block text-sm font-bold text-gray-700 mb-3">Last Name *</label>
+                    <label className="block text-sm font-bold text-heading mb-3">Last Name *</label>
                     <input
                       type="text"
                       name="lastName"
                       value={formData.lastName}
                       onChange={handleInputChange}
-                      className="w-full px-6 py-4 rounded-2xl border-2 border-gray-200 focus:border-blue-500 focus:ring-4 focus:ring-blue-100 outline-none transition-all duration-300 group-hover:border-gray-300"
+                      className="w-full px-6 py-4 rounded-2xl border-2 border-card-bg-alt focus:border-primary-from focus:ring-4 focus:ring-primary-from/20 outline-none transition-all duration-300 group-hover:border-card-bg-alt"
                       placeholder="Enter your last name"
                       required
                     />
@@ -180,25 +180,25 @@ const ContactPage = () => {
 
                 <div className="grid sm:grid-cols-2 gap-6">
                   <div className="group">
-                    <label className="block text-sm font-bold text-gray-700 mb-3">Email *</label>
+                    <label className="block text-sm font-bold text-heading mb-3">Email *</label>
                     <input
                       type="email"
                       name="email"
                       value={formData.email}
                       onChange={handleInputChange}
-                      className="w-full px-6 py-4 rounded-2xl border-2 border-gray-200 focus:border-blue-500 focus:ring-4 focus:ring-blue-100 outline-none transition-all duration-300 group-hover:border-gray-300"
+                      className="w-full px-6 py-4 rounded-2xl border-2 border-card-bg-alt focus:border-primary-from focus:ring-4 focus:ring-primary-from/20 outline-none transition-all duration-300 group-hover:border-card-bg-alt"
                       placeholder="Enter your email address"
                       required
                     />
                   </div>
                   <div className="group">
-                    <label className="block text-sm font-bold text-gray-700 mb-3">Phone</label>
+                    <label className="block text-sm font-bold text-heading mb-3">Phone</label>
                     <input
                       type="tel"
                       name="phone"
                       value={formData.phone}
                       onChange={handleInputChange}
-                      className="w-full px-6 py-4 rounded-2xl border-2 border-gray-200 focus:border-blue-500 focus:ring-4 focus:ring-blue-100 outline-none transition-all duration-300 group-hover:border-gray-300"
+                      className="w-full px-6 py-4 rounded-2xl border-2 border-card-bg-alt focus:border-primary-from focus:ring-4 focus:ring-primary-from/20 outline-none transition-all duration-300 group-hover:border-card-bg-alt"
                       placeholder="Enter your phone number"
                     />
                   </div>
@@ -206,12 +206,12 @@ const ContactPage = () => {
 
                 <div className="grid sm:grid-cols-2 gap-6">
                   <div className="group">
-                    <label className="block text-sm font-bold text-gray-700 mb-3">Department</label>
+                    <label className="block text-sm font-bold text-heading mb-3">Department</label>
                     <select 
                       name="department"
                       value={formData.department}
                       onChange={handleInputChange}
-                      className="w-full px-6 py-4 rounded-2xl border-2 border-gray-200 focus:border-blue-500 focus:ring-4 focus:ring-blue-100 outline-none transition-all duration-300 group-hover:border-gray-300"
+                      className="w-full px-6 py-4 rounded-2xl border-2 border-card-bg-alt focus:border-primary-from focus:ring-4 focus:ring-primary-from/20 outline-none transition-all duration-300 group-hover:border-card-bg-alt"
                     >
                       <option value="">Select Department</option>
                       <option value="general">General Inquiry</option>
@@ -224,12 +224,12 @@ const ContactPage = () => {
                     </select>
                   </div>
                   <div className="group">
-                    <label className="block text-sm font-bold text-gray-700 mb-3">Preferred Contact Method</label>
+                    <label className="block text-sm font-bold text-heading mb-3">Preferred Contact Method</label>
                     <select 
                       name="contactMethod"
                       value={formData.contactMethod}
                       onChange={handleInputChange}
-                      className="w-full px-6 py-4 rounded-2xl border-2 border-gray-200 focus:border-blue-500 focus:ring-4 focus:ring-blue-100 outline-none transition-all duration-300 group-hover:border-gray-300"
+                      className="w-full px-6 py-4 rounded-2xl border-2 border-card-bg-alt focus:border-primary-from focus:ring-4 focus:ring-primary-from/20 outline-none transition-all duration-300 group-hover:border-card-bg-alt"
                     >
                       <option value="email">Email</option>
                       <option value="phone">Phone</option>
@@ -239,13 +239,13 @@ const ContactPage = () => {
                 </div>
 
                 <div className="group">
-                  <label className="block text-sm font-bold text-gray-700 mb-3">Message *</label>
+                  <label className="block text-sm font-bold text-heading mb-3">Message *</label>
                   <textarea
                     rows={6}
                     name="message"
                     value={formData.message}
                     onChange={handleInputChange}
-                    className="w-full px-6 py-4 rounded-2xl border-2 border-gray-200 focus:border-blue-500 focus:ring-4 focus:ring-blue-100 outline-none transition-all duration-300 resize-none group-hover:border-gray-300"
+                    className="w-full px-6 py-4 rounded-2xl border-2 border-card-bg-alt focus:border-primary-from focus:ring-4 focus:ring-primary-from/20 outline-none transition-all duration-300 resize-none group-hover:border-card-bg-alt"
                     placeholder="Please describe your inquiry or concern..."
                     required
                   ></textarea>
@@ -253,7 +253,7 @@ const ContactPage = () => {
 
                 <button
                   type="submit"
-                  className="w-full bg-gradient-to-r from-blue-600 to-blue-700 text-white py-4 rounded-2xl hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-bold flex items-center justify-center space-x-3 shadow-xl hover:shadow-2xl transform hover:scale-105"
+                  className="w-full bg-btn-primary text-white py-4 rounded-2xl hover:bg-btn-hover transition-all duration-300 font-bold flex items-center justify-center space-x-3 shadow-xl hover:shadow-2xl transform hover:scale-105"
                 >
                   <Send size={24} />
                   <span>Send Message</span>
@@ -263,17 +263,17 @@ const ContactPage = () => {
 
             {/* Contact Information */}
             <div className="space-y-8">
-              <div className="bg-white rounded-3xl p-8 shadow-xl">
-                <h3 className="text-2xl font-bold text-gray-900 mb-6">Get in Touch</h3>
+              <div className="bg-card-bg rounded-3xl p-8 shadow-xl">
+                <h3 className="text-2xl font-bold text-heading mb-6">Get in Touch</h3>
                 
                 <div className="space-y-6">
                   <div className="flex items-start space-x-4">
-                    <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
-                      <Phone className="text-blue-600" size={24} />
+                    <div className="w-12 h-12 bg-primary-from/10 rounded-full flex items-center justify-center">
+                      <Phone className="text-primary-from" size={24} />
                     </div>
                     <div>
-                      <h4 className="font-bold text-gray-900 mb-2">Phone</h4>
-                      <p className="text-gray-600 mb-2">Main: +1 (555) 123-4567</p>
+                      <h4 className="font-bold text-heading mb-2">Phone</h4>
+                      <p className="text-text-paragraph mb-2">Main: +1 (555) 123-4567</p>
                       <p className="text-red-600 font-medium">Emergency: +1 (555) 911-HELP</p>
                     </div>
                   </div>
@@ -283,9 +283,9 @@ const ContactPage = () => {
                       <Mail className="text-green-600" size={24} />
                     </div>
                     <div>
-                      <h4 className="font-bold text-gray-900 mb-2">Email</h4>
-                      <p className="text-gray-600 mb-1">info@bigmedix.com</p>
-                      <p className="text-gray-600">appointments@bigmedix.com</p>
+                      <h4 className="font-bold text-heading mb-2">Email</h4>
+                      <p className="text-text-paragraph mb-1">info@bigmedix.com</p>
+                      <p className="text-text-paragraph">appointments@bigmedix.com</p>
                     </div>
                   </div>
 
@@ -294,8 +294,8 @@ const ContactPage = () => {
                       <MapPin className="text-orange-600" size={24} />
                     </div>
                     <div>
-                      <h4 className="font-bold text-gray-900 mb-2">Main Location</h4>
-                      <p className="text-gray-600">123 Medical Plaza<br />Health City, HC 12345</p>
+                      <h4 className="font-bold text-heading mb-2">Main Location</h4>
+                      <p className="text-text-paragraph">123 Medical Plaza<br />Health City, HC 12345</p>
                     </div>
                   </div>
 
@@ -304,9 +304,9 @@ const ContactPage = () => {
                       <Clock className="text-purple-600" size={24} />
                     </div>
                     <div>
-                      <h4 className="font-bold text-gray-900 mb-2">Hours</h4>
-                      <p className="text-gray-600 mb-1">Mon-Fri: 8:00 AM - 6:00 PM</p>
-                      <p className="text-gray-600 mb-1">Saturday: 9:00 AM - 4:00 PM</p>
+                      <h4 className="font-bold text-heading mb-2">Hours</h4>
+                      <p className="text-text-paragraph mb-1">Mon-Fri: 8:00 AM - 6:00 PM</p>
+                      <p className="text-text-paragraph mb-1">Saturday: 9:00 AM - 4:00 PM</p>
                       <p className="text-red-600 font-medium">Emergency: 24/7</p>
                     </div>
                   </div>
@@ -314,17 +314,17 @@ const ContactPage = () => {
               </div>
 
               {/* Department Directory */}
-              <div className="bg-white rounded-3xl p-8 shadow-xl">
-                <h3 className="text-2xl font-bold text-gray-900 mb-6">Department Directory</h3>
+              <div className="bg-card-bg rounded-3xl p-8 shadow-xl">
+                <h3 className="text-2xl font-bold text-heading mb-6">Department Directory</h3>
                 
                 <div className="space-y-4">
                   {departments.map((dept, index) => (
-                    <div key={index} className="flex items-center justify-between p-4 bg-gray-50 rounded-2xl hover:bg-blue-50 transition-colors">
+                    <div key={index} className="flex items-center justify-between p-4 bg-card-bg-alt rounded-2xl hover:bg-primary-from/5 transition-colors">
                       <div>
-                        <div className="font-medium text-gray-900">{dept.name}</div>
-                        <div className="text-sm text-gray-600">Ext. {dept.ext}</div>
+                        <div className="font-medium text-heading">{dept.name}</div>
+                        <div className="text-sm text-text-paragraph">Ext. {dept.ext}</div>
                       </div>
-                      <div className="text-blue-600 font-medium">{dept.phone}</div>
+                    <div className="text-primary-from font-medium">{dept.phone}</div>
                     </div>
                   ))}
                 </div>
@@ -335,18 +335,18 @@ const ContactPage = () => {
       </section>
 
       {/* Locations */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-card-bg">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Our Locations</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-heading mb-6">Our Locations</h2>
+            <p className="text-xl text-text-paragraph max-w-3xl mx-auto">
               Visit us at any of our convenient locations throughout the city. Each facility offers specialized services and expert care.
             </p>
           </div>
           
           <div className="grid lg:grid-cols-3 gap-8">
             {locations.map((location, index) => (
-              <div key={index} className="bg-white rounded-3xl shadow-xl hover:shadow-2xl transition-all duration-300 overflow-hidden group hover:-translate-y-2">
+              <div key={index} className="bg-card-bg rounded-3xl shadow-xl hover:shadow-2xl transition-all duration-300 overflow-hidden group hover:-translate-y-2">
                 <div className="relative overflow-hidden">
                   <img
                     src={location.image}
@@ -361,52 +361,52 @@ const ContactPage = () => {
                 
                 <div className="p-6 space-y-4">
                   <div className="flex items-start space-x-3">
-                    <MapPin className="text-blue-600 mt-1" size={20} />
+                    <MapPin className="text-primary-from mt-1" size={20} />
                     <div>
-                      <div className="font-medium text-gray-900">Address</div>
-                      <div className="text-gray-600">{location.address}</div>
+                      <div className="font-medium text-heading">Address</div>
+                      <div className="text-text-paragraph">{location.address}</div>
                     </div>
                   </div>
                   
                   <div className="flex items-start space-x-3">
                     <Phone className="text-green-600 mt-1" size={20} />
                     <div>
-                      <div className="font-medium text-gray-900">Contact</div>
-                      <div className="text-gray-600">{location.phone}</div>
-                      <div className="text-gray-600">{location.email}</div>
+                      <div className="font-medium text-heading">Contact</div>
+                      <div className="text-text-paragraph">{location.phone}</div>
+                      <div className="text-text-paragraph">{location.email}</div>
                     </div>
                   </div>
                   
                   <div className="flex items-start space-x-3">
                     <Clock className="text-orange-600 mt-1" size={20} />
                     <div>
-                      <div className="font-medium text-gray-900">Hours</div>
-                      <div className="text-gray-600">{location.hours.weekdays}</div>
-                      <div className="text-gray-600">{location.hours.weekend}</div>
+                      <div className="font-medium text-heading">Hours</div>
+                      <div className="text-text-paragraph">{location.hours.weekdays}</div>
+                      <div className="text-text-paragraph">{location.hours.weekend}</div>
                     </div>
                   </div>
 
                   <div className="flex items-start space-x-3">
                     <Car className="text-purple-600 mt-1" size={20} />
                     <div>
-                      <div className="font-medium text-gray-900">Parking</div>
-                      <div className="text-gray-600">{location.parking}</div>
+                      <div className="font-medium text-heading">Parking</div>
+                      <div className="text-text-paragraph">{location.parking}</div>
                     </div>
                   </div>
 
                   <div className="flex items-start space-x-3">
                     <Bus className="text-indigo-600 mt-1" size={20} />
                     <div>
-                      <div className="font-medium text-gray-900">Public Transport</div>
-                      <div className="text-gray-600 text-sm">{location.publicTransport}</div>
+                      <div className="font-medium text-heading">Public Transport</div>
+                      <div className="text-text-paragraph text-sm">{location.publicTransport}</div>
                     </div>
                   </div>
                   
-                  <div className="pt-4 border-t border-gray-200">
-                    <div className="text-sm font-medium text-gray-900 mb-3">Services Available:</div>
+                  <div className="pt-4 border-t border-card-bg-alt">
+                    <div className="text-sm font-medium text-heading mb-3">Services Available:</div>
                     <div className="flex flex-wrap gap-2">
                       {location.services.map((service, serviceIndex) => (
-                        <span key={serviceIndex} className="bg-blue-50 text-blue-600 px-3 py-1 rounded-full text-xs font-medium">
+                        <span key={serviceIndex} className="bg-primary-from/10 text-primary-from px-3 py-1 rounded-full text-xs font-medium">
                           {service}
                         </span>
                       ))}
@@ -425,11 +425,11 @@ const ContactPage = () => {
       </section>
 
       {/* FAQ Section */}
-      <section className="py-20 bg-gray-50">
+      <section className="py-20 bg-content-bg">
         <div className="container mx-auto px-4">
           <div className="text-center mb-16">
-            <h2 className="text-4xl font-bold text-gray-900 mb-6">Frequently Asked Questions</h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold text-heading mb-6">Frequently Asked Questions</h2>
+            <p className="text-xl text-text-paragraph max-w-3xl mx-auto">
               Find quick answers to common questions about our services, appointments, and policies.
             </p>
           </div>
@@ -461,9 +461,9 @@ const ContactPage = () => {
                 answer: "We require at least 24 hours notice for appointment cancellations. Late cancellations or no-shows may result in a fee."
               }
             ].map((faq, index) => (
-              <div key={index} className="bg-white rounded-2xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
-                <h3 className="text-lg font-bold text-gray-900 mb-3">{faq.question}</h3>
-                <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+              <div key={index} className="bg-card-bg rounded-2xl p-6 shadow-lg hover:shadow-xl transition-all duration-300">
+                <h3 className="text-lg font-bold text-heading mb-3">{faq.question}</h3>
+                <p className="text-text-paragraph leading-relaxed">{faq.answer}</p>
               </div>
             ))}
           </div>

--- a/src/pages/DoctorsPage.tsx
+++ b/src/pages/DoctorsPage.tsx
@@ -144,10 +144,10 @@ const DoctorsPage = () => {
   return (
     <div className="pt-32">
       {/* Hero Section */}
-      <section className="py-20 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white relative overflow-hidden">
+      <section className="py-20 bg-gradient-to-br from-primary-from to-primary-to text-white relative overflow-hidden">
         <div className="absolute inset-0 opacity-10">
-          <div className="absolute top-20 left-20 w-64 h-64 bg-white rounded-full blur-3xl"></div>
-          <div className="absolute bottom-20 right-20 w-64 h-64 bg-orange-500 rounded-full blur-3xl"></div>
+          <div className="absolute top-20 left-20 w-64 h-64 bg-card-bg rounded-full blur-3xl"></div>
+          <div className="absolute bottom-20 right-20 w-64 h-64 bg-accent rounded-full blur-3xl"></div>
         </div>
         
         <div className="container mx-auto px-4 relative z-10">
@@ -166,7 +166,7 @@ const DoctorsPage = () => {
       </section>
 
       {/* Filter Section */}
-      <section className="py-12 bg-white border-b">
+      <section className="py-12 bg-card-bg border-b">
         <div className="container mx-auto px-4">
           <div className="flex flex-wrap justify-center gap-4">
             {specialties.map((specialty) => (
@@ -175,8 +175,8 @@ const DoctorsPage = () => {
                 onClick={() => setSelectedSpecialty(specialty)}
                 className={`px-6 py-3 rounded-full text-sm font-medium transition-all duration-300 ${
                   selectedSpecialty === specialty
-                    ? 'bg-blue-600 text-white shadow-lg transform scale-105'
-                    : 'bg-gray-100 text-gray-600 hover:bg-blue-50 hover:text-blue-600'
+                    ? 'bg-btn-primary text-white shadow-lg transform scale-105'
+                    : 'bg-card-bg-alt text-text-paragraph hover:bg-primary-from/10 hover:text-primary-from'
                 }`}
               >
                 {specialty === 'all' ? 'All Specialties' : specialty}
@@ -195,7 +195,7 @@ const DoctorsPage = () => {
                 key={index}
                 data-index={index}
                 data-animate="doctor"
-                className={`group bg-white rounded-3xl shadow-xl hover:shadow-2xl transition-all duration-500 overflow-hidden cursor-pointer transform hover:-translate-y-6 ${
+                className={`group bg-card-bg rounded-3xl shadow-xl hover:shadow-2xl transition-all duration-500 overflow-hidden cursor-pointer transform hover:-translate-y-6 ${
                   visibleItems.has(index.toString()) 
                     ? 'translate-y-0 opacity-100' 
                     : 'translate-y-8 opacity-0'
@@ -213,22 +213,22 @@ const DoctorsPage = () => {
                   {/* Rating Badge */}
                   <div className="absolute top-4 right-4 bg-white/90 backdrop-blur-sm rounded-full px-3 py-2 flex items-center space-x-1 shadow-lg">
                     <Star className="text-yellow-400 fill-current" size={16} />
-                    <span className="text-sm font-bold text-gray-800">{doctor.rating}</span>
+                    <span className="text-sm font-bold text-heading">{doctor.rating}</span>
                   </div>
 
                   {/* Specialty Badge */}
-                  <div className="absolute bottom-4 left-4 bg-gradient-to-r from-blue-600 to-blue-700 text-white px-4 py-2 rounded-full text-sm font-semibold shadow-lg">
+                  <div className="absolute bottom-4 left-4 bg-gradient-to-r from-primary-from to-primary-to text-white px-4 py-2 rounded-full text-sm font-semibold shadow-lg">
                     {doctor.specialty}
                   </div>
                 </div>
                 
                 <div className="p-6 space-y-4">
                   <div>
-                    <h3 className="text-2xl font-bold text-gray-900 mb-2 group-hover:text-blue-600 transition-colors">
+                    <h3 className="text-2xl font-bold text-heading mb-2 group-hover:text-primary-from transition-colors">
                       {doctor.name}
                     </h3>
-                    <div className="text-blue-600 font-medium mb-2">{doctor.position}</div>
-                    <div className="flex items-center space-x-4 text-sm text-gray-600 mb-4">
+                    <div className="text-primary-from font-medium mb-2">{doctor.position}</div>
+                    <div className="flex items-center space-x-4 text-sm text-text-paragraph mb-4">
                       <div className="flex items-center space-x-1">
                         <Calendar size={16} />
                         <span>{doctor.experience}</span>
@@ -241,18 +241,18 @@ const DoctorsPage = () => {
                   </div>
 
                   <div className="space-y-3">
-                    <div className="flex items-center space-x-2 text-sm text-gray-600">
-                      <GraduationCap size={16} className="text-blue-600" />
+                    <div className="flex items-center space-x-2 text-sm text-text-paragraph">
+                      <GraduationCap size={16} className="text-primary-from" />
                       <span className="font-medium">{doctor.education}</span>
                     </div>
                     
-                    <div className="flex items-center space-x-2 text-sm text-gray-600">
+                    <div className="flex items-center space-x-2 text-sm text-text-paragraph">
                       <Clock size={16} className="text-green-600" />
                       <span>{doctor.availability}</span>
                     </div>
                     
                     <div className="flex items-center justify-between text-sm">
-                      <span className="text-gray-600">{doctor.reviews} patient reviews</span>
+                      <span className="text-text-paragraph">{doctor.reviews} patient reviews</span>
                       <div className="flex items-center space-x-1">
                         {[...Array(5)].map((_, i) => (
                           <Star
@@ -266,15 +266,15 @@ const DoctorsPage = () => {
                   </div>
 
                   <div className="pt-4 border-t border-gray-100">
-                    <div className="text-sm text-gray-600 mb-3">Specialties:</div>
+                  <div className="text-sm text-text-paragraph mb-3">Specialties:</div>
                     <div className="flex flex-wrap gap-2">
                       {doctor.specialties.slice(0, 2).map((specialty, i) => (
-                        <span key={i} className="bg-blue-50 text-blue-600 px-3 py-1 rounded-full text-xs font-medium">
+                        <span key={i} className="bg-primary-from/10 text-primary-from px-3 py-1 rounded-full text-xs font-medium">
                           {specialty}
                         </span>
                       ))}
                       {doctor.specialties.length > 2 && (
-                        <span className="bg-gray-100 text-gray-600 px-3 py-1 rounded-full text-xs font-medium">
+                        <span className="bg-card-bg-alt text-text-paragraph px-3 py-1 rounded-full text-xs font-medium">
                           +{doctor.specialties.length - 2} more
                         </span>
                       )}
@@ -282,11 +282,11 @@ const DoctorsPage = () => {
                   </div>
 
                   <div className="flex space-x-2">
-                    <button className="flex-1 bg-gradient-to-r from-blue-600 to-blue-700 text-white py-3 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105">
+                    <button className="flex-1 bg-gradient-to-r from-primary-from to-primary-to text-white py-3 rounded-full hover:from-primary-to hover:to-primary-from transition-all duration-300 font-semibold shadow-lg hover:shadow-xl transform hover:scale-105">
                       Book Appointment
                     </button>
-                    <button className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center hover:bg-blue-50 transition-colors">
-                      <Phone size={18} className="text-blue-600" />
+                    <button className="w-12 h-12 bg-card-bg-alt rounded-full flex items-center justify-center hover:bg-primary-from/10 transition-colors">
+                      <Phone size={18} className="text-primary-from" />
                     </button>
                   </div>
                 </div>
@@ -297,7 +297,7 @@ const DoctorsPage = () => {
       </section>
 
       {/* Doctor Spotlight */}
-      <section className="py-20 bg-white">
+      <section className="py-20 bg-card-bg">
         <div className="container mx-auto px-4">
           <div className="bg-gradient-to-br from-blue-50 to-white rounded-3xl p-8 lg:p-12 shadow-xl">
             <div className="grid lg:grid-cols-2 gap-12 items-center">
@@ -309,12 +309,12 @@ const DoctorsPage = () => {
                 />
                 <div className="absolute -bottom-6 -right-6 bg-white rounded-2xl p-6 shadow-xl">
                   <div className="flex items-center space-x-4">
-                    <div className="w-12 h-12 bg-gradient-to-br from-blue-500 to-blue-600 rounded-full flex items-center justify-center">
+                    <div className="w-12 h-12 bg-gradient-to-br from-primary-from to-primary-to rounded-full flex items-center justify-center">
                       <Award className="text-white" size={20} />
                     </div>
                     <div>
-                      <div className="font-bold text-gray-800">Chief Cardiologist</div>
-                      <div className="text-sm text-gray-600">Department Head</div>
+                      <div className="font-bold text-heading">Chief Cardiologist</div>
+                      <div className="text-sm text-text-paragraph">Department Head</div>
                     </div>
                   </div>
                 </div>
@@ -322,19 +322,19 @@ const DoctorsPage = () => {
               
               <div className="space-y-6">
                 <div>
-                  <div className="text-blue-600 font-medium mb-2">Doctor Spotlight</div>
-                  <h3 className="text-4xl font-bold text-gray-900 mb-4">{doctors[0].name}</h3>
-                  <div className="text-xl text-gray-600 mb-6">{doctors[0].position}</div>
+                  <div className="text-primary-from font-medium mb-2">Doctor Spotlight</div>
+                  <h3 className="text-4xl font-bold text-heading mb-4">{doctors[0].name}</h3>
+                  <div className="text-xl text-text-paragraph mb-6">{doctors[0].position}</div>
                 </div>
                 
-                <p className="text-gray-600 leading-relaxed text-lg">
+                <p className="text-text-paragraph leading-relaxed text-lg">
                   {doctors[0].bio}
                 </p>
                 
                 <div className="grid md:grid-cols-2 gap-6">
                   <div>
-                    <h4 className="font-bold text-gray-900 mb-3">Education & Certifications</h4>
-                    <ul className="space-y-2 text-sm text-gray-600">
+                    <h4 className="font-bold text-heading mb-3">Education & Certifications</h4>
+                    <ul className="space-y-2 text-sm text-text-paragraph">
                       <li>• {doctors[0].education}</li>
                       {doctors[0].certifications.map((cert, index) => (
                         <li key={index}>• {cert}</li>
@@ -343,25 +343,25 @@ const DoctorsPage = () => {
                   </div>
                   
                   <div>
-                    <h4 className="font-bold text-gray-900 mb-3">Contact Information</h4>
-                    <div className="space-y-2 text-sm text-gray-600">
+                    <h4 className="font-bold text-heading mb-3">Contact Information</h4>
+                    <div className="space-y-2 text-sm text-text-paragraph">
                       <div className="flex items-center space-x-2">
-                        <Phone size={16} className="text-blue-600" />
+                        <Phone size={16} className="text-primary-from" />
                         <span>{doctors[0].phone}</span>
                       </div>
                       <div className="flex items-center space-x-2">
-                        <Mail size={16} className="text-green-600" />
+                        <Mail size={16} className="text-accent" />
                         <span>{doctors[0].email}</span>
                       </div>
                       <div className="flex items-center space-x-2">
-                        <Clock size={16} className="text-orange-600" />
+                        <Clock size={16} className="text-accent" />
                         <span>{doctors[0].availability}</span>
                       </div>
                     </div>
                   </div>
                 </div>
                 
-                <button className="bg-gradient-to-r from-blue-600 to-blue-700 text-white px-8 py-4 rounded-full hover:from-blue-700 hover:to-blue-800 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
+                <button className="bg-gradient-to-r from-primary-from to-primary-to text-white px-8 py-4 rounded-full hover:from-primary-to hover:to-primary-from transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
                   Schedule with Dr. {doctors[0].name.split(' ')[1]}
                 </button>
               </div>
@@ -371,7 +371,7 @@ const DoctorsPage = () => {
       </section>
 
       {/* Call to Action */}
-      <section className="py-20 bg-gradient-to-br from-blue-600 to-blue-700 text-white">
+      <section className="py-20 bg-gradient-to-br from-primary-from to-primary-to text-white">
         <div className="container mx-auto px-4 text-center">
           <h2 className="text-4xl font-bold mb-6">Ready to Meet Your Doctor?</h2>
           <p className="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
@@ -379,7 +379,7 @@ const DoctorsPage = () => {
           </p>
           
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <button className="bg-gradient-to-r from-orange-500 to-red-500 text-white px-8 py-4 rounded-full hover:from-orange-600 hover:to-red-600 transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
+            <button className="bg-gradient-to-r from-btn-primary to-btn-hover text-white px-8 py-4 rounded-full hover:from-btn-hover hover:to-btn-primary transition-all duration-300 font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105">
               Book Appointment Online
             </button>
             <button className="bg-white/20 backdrop-blur-sm text-white px-8 py-4 rounded-full hover:bg-white/30 transition-all duration-300 font-semibold border border-white/30">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-export default {
-  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,27 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        'primary-from': '#0F4537',
+        'primary-to': '#2E6656',
+        accent: '#FA6F42',
+        'accent-hover': '#F8753D',
+        'btn-primary': '#FA6F42',
+        'btn-hover': '#F8753D',
+        'bg-cta-from': '#0F4537',
+        'bg-cta-to': '#2E6656',
+        'content-bg': '#F4F9F7',
+        'card-bg': '#FAFAFA',
+        'card-bg-alt': '#F1F1F1',
+        'text-heading': '#000000',
+        'text-paragraph': '#4A4A4A',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- extend Tailwind palette with button and card tokens
- normalize footer, contact, and doctors pages to use semantic colors
- improve mobile and desktop navigation color contrast

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' in several files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685131922ac08324865b1140a5318288